### PR TITLE
Add BatchRenderGroupId to Batcher and TextRenderer

### DIFF
--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 orbit_gl::CaptureViewElementTester::CaptureViewElementTester()
-    : viewport_(1920, 1080), primitive_assembler_(&batcher_, &picking_manager_) {}
+    : viewport_(1920, 1080), primitive_assembler_(&batcher_, &state_manager_, &picking_manager_) {}
 
 void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
   TestWidthPropagationToChildren(element);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -4,7 +4,6 @@
 
 #include "OrbitGl/CaptureWindow.h"
 
-#include <GL/gl.h>
 #include <GteVector.h>
 #include <absl/container/btree_map.h>
 #include <absl/strings/str_format.h>
@@ -569,7 +568,7 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
   }
 
   for (const orbit_gl::BatchRenderGroupId& group : all_groups_sorted) {
-    auto stencil = render_group_manager_.GetGroupState(group.name).stencil;
+    orbit_gl::StencilConfig stencil = render_group_manager_.GetGroupState(group.name).stencil;
     if (stencil.enabled) {
       Vec2i stencil_screen_pos = viewport_.WorldToScreen(Vec2(stencil.pos[0], stencil.pos[1]));
       Vec2i stencil_screen_size = viewport_.WorldToScreen(Vec2(stencil.size[0], stencil.size[1]));

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -4,12 +4,17 @@
 
 #include "OrbitGl/CaptureWindow.h"
 
+#include <GL/gl.h>
 #include <GteVector.h>
 #include <absl/container/btree_map.h>
 #include <absl/strings/str_format.h>
+#include <qnamespace.h>
 
+#include <QFontDatabase>
+#include <QOpenGLFunctions>
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -26,7 +31,6 @@
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "DisplayFormats/DisplayFormats.h"
-#include "Introspection/Introspection.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "OrbitBase/Append.h"
@@ -34,6 +38,7 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/BatcherInterface.h"
 #include "OrbitGl/CaptureViewElement.h"
 #include "OrbitGl/CoreMath.h"
@@ -41,6 +46,7 @@
 #include "OrbitGl/GlUtils.h"
 #include "OrbitGl/OpenGlBatcher.h"
 #include "OrbitGl/OrbitApp.h"
+#include "OrbitGl/PickingManager.h"
 #include "OrbitGl/PrimitiveAssembler.h"
 #include "OrbitGl/QtTextRenderer.h"
 #include "OrbitGl/TextRenderer.h"
@@ -545,27 +551,39 @@ void CaptureWindow::Draw(QPainter* painter) {
 }
 
 void CaptureWindow::RenderAllLayers(QPainter* painter) {
-  std::vector<float> all_layers{};
-  if (time_graph_ != nullptr) {
-    all_layers = time_graph_->GetBatcher().GetLayers();
-    orbit_base::Append(all_layers, time_graph_->GetTextRenderer()->GetLayers());
-  }
-  orbit_base::Append(all_layers, ui_batcher_.GetLayers());
-  orbit_base::Append(all_layers, text_renderer_.GetLayers());
+  std::vector<orbit_gl::BatchRenderGroupId> all_groups_sorted{};
 
-  // Sort and remove duplicates.
-  std::sort(all_layers.begin(), all_layers.end());
-  auto it = std::unique(all_layers.begin(), all_layers.end());
-  all_layers.resize(std::distance(all_layers.begin(), it));
-  if (all_layers.size() > GlCanvas::kMaxNumberRealZLayers) {
-    ORBIT_ERROR("Too many z-layers. The current number is %d", all_layers.size());
-  }
-
-  for (float layer : all_layers) {
+  {
+    ORBIT_SCOPE("Layer gathering and sorting");
     if (time_graph_ != nullptr) {
-      time_graph_->GetBatcher().DrawLayer(layer, picking_mode_ != PickingMode::kNone);
+      all_groups_sorted = time_graph_->GetBatcher().GetNonEmptyRenderGroups();
+      orbit_base::Append(all_groups_sorted, time_graph_->GetTextRenderer()->GetRenderGroups());
     }
-    ui_batcher_.DrawLayer(layer, picking_mode_ != PickingMode::kNone);
+    orbit_base::Append(all_groups_sorted, ui_batcher_.GetNonEmptyRenderGroups());
+    orbit_base::Append(all_groups_sorted, text_renderer_.GetRenderGroups());
+
+    // Sort and remove duplicates.
+    std::sort(all_groups_sorted.begin(), all_groups_sorted.end());
+    auto it = std::unique(all_groups_sorted.begin(), all_groups_sorted.end());
+    all_groups_sorted.erase(it, all_groups_sorted.end());
+  }
+
+  for (const orbit_gl::BatchRenderGroupId& group : all_groups_sorted) {
+    auto stencil = render_group_manager_.GetGroupState(group.name).stencil;
+    if (stencil.enabled) {
+      Vec2i stencil_screen_pos = viewport_.WorldToScreen(Vec2(stencil.pos[0], stencil.pos[1]));
+      Vec2i stencil_screen_size = viewport_.WorldToScreen(Vec2(stencil.size[0], stencil.size[1]));
+      painter->setClipRect(QRect(stencil_screen_pos[0], stencil_screen_pos[1],
+                                 stencil_screen_size[0], stencil_screen_size[1]));
+      painter->setClipping(true);
+    } else {
+      painter->setClipping(false);
+    }
+
+    if (time_graph_ != nullptr) {
+      time_graph_->GetBatcher().DrawRenderGroup(group, picking_mode_ != PickingMode::kNone);
+    }
+    ui_batcher_.DrawRenderGroup(group, picking_mode_ != PickingMode::kNone);
 
     // The painter is in "native painting mode" all the time and we merely leave it for rendering
     // the text here. Compare GlCanvas::Render - that's where we enter native painting.
@@ -573,8 +591,11 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
     painter->endNativePainting();
 
     if (picking_mode_ == PickingMode::kNone) {
-      text_renderer_.RenderLayer(painter, layer);
-      RenderText(painter, layer);
+      text_renderer_.DrawRenderGroup(painter, render_group_manager_, group);
+      if (time_graph_ != nullptr) {
+        ORBIT_SCOPE("CaptureWindow: Text Rendering");
+        time_graph_->GetTextRenderer()->DrawRenderGroup(painter, render_group_manager_, group);
+      }
     }
 
     painter->beginNativePainting();
@@ -601,8 +622,9 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(CaptureData* capture_data) {
-  time_graph_ = std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data,
-                                            &GetPickingManager(), time_graph_layout_);
+  time_graph_ =
+      std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data, &GetPickingManager(),
+                                  &render_group_manager_, time_graph_layout_);
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
@@ -703,14 +725,6 @@ std::string CaptureWindow::GetPerformanceInfo() const {
 }
 
 std::string CaptureWindow::GetSelectionSummary() const { return selection_stats_.GetSummary(); }
-
-void CaptureWindow::RenderText(QPainter* painter, float layer) {
-  ORBIT_SCOPE_FUNCTION;
-  if (time_graph_ == nullptr) return;
-  if (picking_mode_ == PickingMode::kNone) {
-    time_graph_->DrawText(painter, layer);
-  }
-}
 
 void CaptureWindow::RenderHelpUi() {
   constexpr int kOffset = 30;

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -15,6 +15,7 @@
 #include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitGl/AccessibleInterfaceProvider.h"
+#include "OrbitGl/BatchRenderGroup.h"
 
 // TODO(b/227341686) z-values should not be of `float` type. E.g. make them `uint`.
 // Tracks: 0.0 - 0.1
@@ -62,9 +63,10 @@ const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas()
     : AccessibleInterfaceProvider(),
+      text_renderer_(),
       viewport_(0, 0),
       ui_batcher_(BatcherId::kUi),
-      primitive_assembler_(&ui_batcher_, &picking_manager_) {
+      primitive_assembler_(&ui_batcher_, &render_group_manager_, &picking_manager_) {
   // Note that `GlCanvas` is the bridge to OpenGl content, and `GlCanvas`'s parent needs special
   // handling for accessibility. Thus, we use `nullptr` here.
   text_renderer_.SetViewport(&viewport_);
@@ -189,6 +191,7 @@ void GlCanvas::Render(QPainter* painter, int width, int height) {
   if (!IsRedrawNeeded()) {
     return;
   }
+
   painter->beginNativePainting();
   redraw_requested_ = false;
   ui_batcher_.ResetElements();

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -299,11 +299,6 @@ void IntrospectionWindow::Draw(QPainter* painter) {
   CaptureWindow::Draw(painter);
 }
 
-void IntrospectionWindow::RenderText(QPainter* painter, float layer) {
-  ORBIT_SCOPE_FUNCTION;
-  CaptureWindow::RenderText(painter, layer);
-}
-
 void IntrospectionWindow::ToggleRecording() {
   if (!IsIntrospecting()) {
     StartIntrospection();

--- a/src/OrbitGl/MockBatcher.cpp
+++ b/src/OrbitGl/MockBatcher.cpp
@@ -23,7 +23,7 @@ void MockBatcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
   if (from[1] == to[1]) num_horizontal_lines_++;
   AdjustDrawingBoundaries({from[0], from[1]});
   AdjustDrawingBoundaries({to[0], to[1]});
-  z_layers_.insert(z);
+  render_groups_.insert(BatchRenderGroupId(z));
 }
 void MockBatcher::AddBox(const Quad& box, float z, const std::array<Color, 4>& colors,
                          const Color& /*picking_color*/,
@@ -32,7 +32,7 @@ void MockBatcher::AddBox(const Quad& box, float z, const std::array<Color, 4>& c
   for (int i = 0; i < 4; i++) {
     AdjustDrawingBoundaries(box.vertices[i]);
   }
-  z_layers_.insert(z);
+  render_groups_.insert(BatchRenderGroupId(z));
 }
 void MockBatcher::AddTriangle(const Triangle& triangle, float z, const std::array<Color, 3>& colors,
                               const Color& /*picking_color*/,
@@ -41,7 +41,7 @@ void MockBatcher::AddTriangle(const Triangle& triangle, float z, const std::arra
   for (int i = 0; i < 3; i++) {
     AdjustDrawingBoundaries(triangle.vertices[i]);
   }
-  z_layers_.insert(z);
+  render_groups_.insert(BatchRenderGroupId(z));
 }
 
 void MockBatcher::ResetElements() {
@@ -52,7 +52,7 @@ void MockBatcher::ResetElements() {
   num_vertical_lines_ = 0;
   min_point_ = Vec2{std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
   max_point_ = Vec2{std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest()};
-  z_layers_.clear();
+  render_groups_.clear();
 }
 
 uint32_t MockBatcher::GetNumElements() const {
@@ -91,10 +91,11 @@ bool MockBatcher::IsEverythingInsideRectangle(const Vec2& start, const Vec2& siz
 }
 
 bool MockBatcher::IsEverythingBetweenZLayers(float z_layer_min, float z_layer_max) const {
-  return std::find_if_not(z_layers_.begin(), z_layers_.end(),
-                          [z_layer_min, z_layer_max](float layer) {
-                            return ClosedInterval<float>{z_layer_min, z_layer_max}.Contains(layer);
-                          }) == z_layers_.end();
+  return std::find_if_not(
+             render_groups_.begin(), render_groups_.end(),
+             [z_layer_min, z_layer_max](const BatchRenderGroupId& group) {
+               return ClosedInterval<float>{z_layer_min, z_layer_max}.Contains(group.layer);
+             }) == render_groups_.end();
 }
 
 void MockBatcher::AdjustDrawingBoundaries(Vec2 point) {

--- a/src/OrbitGl/MockTextRenderer.cpp
+++ b/src/OrbitGl/MockTextRenderer.cpp
@@ -16,7 +16,7 @@
 namespace orbit_gl {
 
 // Clearing counters also in creation to not duplicate code.
-MockTextRenderer::MockTextRenderer() : TextRenderer() { Clear(); }
+MockTextRenderer::MockTextRenderer() { Clear(); }
 
 void MockTextRenderer::Clear() {
   min_point_ = Vec2{std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -21,7 +21,7 @@
 namespace orbit_gl {
 
 void OpenGlBatcher::ResetElements() {
-  for (auto& [_, buffer] : primitive_buffers_by_group_) {
+  for (auto& [unused_group_id, buffer] : primitive_buffers_by_group_) {
     buffer.Reset();
   }
   user_data_.clear();
@@ -101,7 +101,6 @@ void OpenGlBatcher::AddTriangle(const Triangle& triangle, float z,
         buffers.triangle_buffer.triangles_.size() == 0) {
       continue;
     }
-    // ORBIT_CHECK(buffers.group == group);
     result.push_back(group);
   }
   return result;

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -14,17 +14,19 @@
 
 #include "Introspection/Introspection.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/TranslationStack.h"
 
 namespace orbit_gl {
 
 void OpenGlBatcher::ResetElements() {
-  for (auto& [unused_layer, buffer] : primitive_buffers_by_layer_) {
+  for (auto& [_, buffer] : primitive_buffers_by_group_) {
     buffer.Reset();
   }
   user_data_.clear();
   ORBIT_CHECK(translations_.IsEmpty());
+  current_render_group_ = BatchRenderGroupId();
 }
 
 static void MoveLineToPixelCenterIfHorizontal(Line& line) {
@@ -46,7 +48,8 @@ void OpenGlBatcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
   // TODO(b/195386885) This is a hack to address the issue that some horizontal lines in the graph
   // tracks are missing. We need a better solution for this issue.
   MoveLineToPixelCenterIfHorizontal(line);
-  auto& buffer = primitive_buffers_by_layer_[layer_z_value];
+  current_render_group_.layer = layer_z_value;
+  auto& buffer = primitive_buffers_by_group_[current_render_group_];
 
   buffer.line_buffer.lines_.emplace_back(line);
   buffer.line_buffer.colors_.push_back_n(color, 2);
@@ -64,7 +67,8 @@ void OpenGlBatcher::AddBox(const Quad& box, float z, const std::array<Color, 4>&
     layer_z_value = layered_vec2.z;
   }
 
-  auto& buffer = primitive_buffers_by_layer_[layer_z_value];
+  current_render_group_.layer = layer_z_value;
+  auto& buffer = primitive_buffers_by_group_[current_render_group_];
   buffer.box_buffer.boxes_.emplace_back(rounded_box);
   buffer.box_buffer.colors_.push_back(colors);
   buffer.box_buffer.picking_colors_.push_back_n(picking_color, 4);
@@ -81,49 +85,60 @@ void OpenGlBatcher::AddTriangle(const Triangle& triangle, float z,
     vertex = layered_vec2.xy;
     layer_z_value = layered_vec2.z;
   }
-  auto& buffer = primitive_buffers_by_layer_[layer_z_value];
+
+  current_render_group_.layer = layer_z_value;
+  auto& buffer = primitive_buffers_by_group_[current_render_group_];
   buffer.triangle_buffer.triangles_.emplace_back(rounded_tri);
   buffer.triangle_buffer.colors_.push_back(colors);
   buffer.triangle_buffer.picking_colors_.push_back_n(picking_color, 3);
   user_data_.push_back(std::move(user_data));
 }
 
-[[nodiscard]] std::vector<float> OpenGlBatcher::GetLayers() const {
-  std::vector<float> layers;
-  for (const auto& [layer, _] : primitive_buffers_by_layer_) {
-    layers.push_back(layer);
+[[nodiscard]] std::vector<BatchRenderGroupId> OpenGlBatcher::GetNonEmptyRenderGroups() const {
+  std::vector<BatchRenderGroupId> result;
+  for (const auto& [group, buffers] : primitive_buffers_by_group_) {
+    if (buffers.box_buffer.boxes_.size() == 0 && buffers.line_buffer.lines_.size() == 0 &&
+        buffers.triangle_buffer.triangles_.size() == 0) {
+      continue;
+    }
+    // ORBIT_CHECK(buffers.group == group);
+    result.push_back(group);
   }
-  return layers;
+  return result;
 };
 
-void OpenGlBatcher::DrawLayer(float layer, bool picking) {
+void OpenGlBatcher::DrawRenderGroup(const BatchRenderGroupId& group, bool picking) {
   ORBIT_SCOPE_FUNCTION;
-  if (primitive_buffers_by_layer_.count(layer) == 0u) return;
+  if (primitive_buffers_by_group_.count(group) == 0u) return;
   initializeOpenGLFunctions();
-  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
+  glPushAttrib(GL_ALL_ATTRIB_BITS);
+  glPushClientAttrib(GL_CLIENT_ALL_ATTRIB_BITS);
   glDisable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
+
   if (picking) {
     glDisable(GL_BLEND);
   } else {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   }
-  glDisable(GL_CULL_FACE);
+
   glEnableClientState(GL_VERTEX_ARRAY);
   glEnableClientState(GL_COLOR_ARRAY);
   glEnable(GL_TEXTURE_2D);
 
-  DrawBoxBuffer(layer, picking);
-  DrawLineBuffer(layer, picking);
-  DrawTriangleBuffer(layer, picking);
+  DrawBoxBuffer(group, picking);
+  DrawLineBuffer(group, picking);
+  DrawTriangleBuffer(group, picking);
 
   glDisableClientState(GL_COLOR_ARRAY);
   glDisableClientState(GL_VERTEX_ARRAY);
   glPopAttrib();
+  glPopClientAttrib();
 }
 
-void OpenGlBatcher::DrawBoxBuffer(float layer, bool picking) {
-  auto& box_buffer = primitive_buffers_by_layer_.at(layer).box_buffer;
+void OpenGlBatcher::DrawBoxBuffer(const BatchRenderGroupId& group, bool picking) {
+  auto& box_buffer = primitive_buffers_by_group_.at(group).box_buffer;
   const orbit_containers::Block<Quad, orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK>*
       box_block = box_buffer.boxes_.root();
   const orbit_containers::Block<Color, orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK* 4>*
@@ -141,8 +156,8 @@ void OpenGlBatcher::DrawBoxBuffer(float layer, bool picking) {
   }
 }
 
-void OpenGlBatcher::DrawLineBuffer(float layer, bool picking) {
-  auto& line_buffer = primitive_buffers_by_layer_.at(layer).line_buffer;
+void OpenGlBatcher::DrawLineBuffer(const BatchRenderGroupId& group, bool picking) {
+  auto& line_buffer = primitive_buffers_by_group_.at(group).line_buffer;
   const orbit_containers::Block<Line, orbit_gl_internal::LineBuffer::NUM_LINES_PER_BLOCK>*
       line_block = line_buffer.lines_.root();
   const orbit_containers::Block<Color, orbit_gl_internal::LineBuffer::NUM_LINES_PER_BLOCK* 2>*
@@ -159,8 +174,8 @@ void OpenGlBatcher::DrawLineBuffer(float layer, bool picking) {
   }
 }
 
-void OpenGlBatcher::DrawTriangleBuffer(float layer, bool picking) {
-  auto& triangle_buffer = primitive_buffers_by_layer_.at(layer).triangle_buffer;
+void OpenGlBatcher::DrawTriangleBuffer(const BatchRenderGroupId& group, bool picking) {
+  auto& triangle_buffer = primitive_buffers_by_group_.at(group).triangle_buffer;
   const orbit_containers::Block<
       Triangle, orbit_gl_internal::TriangleBuffer::NUM_TRIANGLES_PER_BLOCK>* triangle_block =
       triangle_buffer.triangles_.root();
@@ -232,7 +247,7 @@ size_t CalculateBlockChainNonEmptyBlockCount(const orbit_containers::BlockChain<
 [[nodiscard]] Batcher::Statistics OpenGlBatcher::GetStatistics() const {
   Statistics result;
 
-  for (auto& layer : primitive_buffers_by_layer_) {
+  for (const auto& layer : primitive_buffers_by_group_) {
     result.reserved_memory += CalculateBlockChainMemory(layer.second.box_buffer.boxes_);
     result.reserved_memory += CalculateBlockChainMemory(layer.second.box_buffer.picking_colors_);
     result.reserved_memory += CalculateBlockChainMemory(layer.second.box_buffer.colors_);
@@ -254,7 +269,7 @@ size_t CalculateBlockChainNonEmptyBlockCount(const orbit_containers::BlockChain<
         CalculateBlockChainNonEmptyBlockCount(layer.second.triangle_buffer.triangles_);
   }
 
-  result.stored_layers = primitive_buffers_by_layer_.size();
+  result.stored_layers = primitive_buffers_by_group_.size();
 
   return result;
 }

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "Containers/BlockChain.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/Batcher.h"
 #include "OrbitGl/BatcherInterface.h"
 #include "OrbitGl/CoreMath.h"
@@ -58,8 +59,8 @@ class FakeOpenGlBatcher : public OpenGlBatcher {
   // Simulate drawing by simple appending all colors to internal
   // buffers. Only a single color per element will be appended
   // (start point for line, first vertex for triangle and box)
-  void DrawLayer(float layer, bool picking = false) override {
-    auto& buffer = primitive_buffers_by_layer_.at(layer);
+  void DrawRenderGroup(const BatchRenderGroupId& group, bool picking = false) override {
+    auto& buffer = primitive_buffers_by_group_.at(group);
     if (picking) {
       for (auto it = buffer.line_buffer.picking_colors_.begin();
            it != buffer.line_buffer.picking_colors_.end();) {
@@ -105,8 +106,9 @@ class FakeOpenGlBatcher : public OpenGlBatcher {
     }
   }
 
-  const orbit_gl_internal::PrimitiveBuffers& GetInternalBuffers(float layer) const {
-    return primitive_buffers_by_layer_.at(layer);
+  const orbit_gl_internal::PrimitiveBuffers& GetInternalBuffers(
+      const BatchRenderGroupId& group) const {
+    return primitive_buffers_by_group_.at(group);
   }
 
  private:
@@ -119,8 +121,8 @@ void ExpectDraw(FakeOpenGlBatcher& batcher, uint32_t line_count, uint32_t triang
                 uint32_t box_count) {
   batcher.ResetMockDrawCounts();
 
-  for (auto layer : batcher.GetLayers()) {
-    batcher.DrawLayer(layer);
+  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+    batcher.DrawRenderGroup(group);
   }
   EXPECT_EQ(batcher.GetDrawnLineColors().size(), line_count);
   EXPECT_EQ(batcher.GetDrawnTriangleColors().size(), triangle_count);
@@ -177,8 +179,8 @@ TEST(OpenGlBatcher, PickingSimpleElements) {
   batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255),
                        std::move(box_user_data));
 
-  for (auto layer : batcher.GetLayers()) {
-    batcher.DrawLayer(layer, true);
+  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+    batcher.DrawRenderGroup(group, true);
   }
 
   ExpectCustomDataEq(batcher, batcher.GetDrawnLineColors()[0], line_custom_data);
@@ -208,8 +210,8 @@ TEST(OpenGlBatcher, MultipleDrawCalls) {
   batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255),
                        std::move(box_user_data));
 
-  for (auto layer : batcher.GetLayers()) {
-    batcher.DrawLayer(layer, true);
+  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+    batcher.DrawRenderGroup(group, true);
   }
 
   auto line_color = batcher.GetDrawnLineColors()[0];
@@ -252,7 +254,7 @@ TEST(OpenGlBatcher, TranslationsAreAutomaticallyAdded) {
                                        original_expectation.end_point + transform};
 
   const auto first_from_layer = [&batcher = std::as_const(batcher)](float z) {
-    return *batcher.GetInternalBuffers(z).line_buffer.lines_.begin();
+    return *batcher.GetInternalBuffers(BatchRenderGroupId(z)).line_buffer.lines_.begin();
   };
 
   const auto add_line_assert_eq = [&batcher, &first_from_layer](const Line3D& expectation) {

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -121,7 +121,7 @@ void ExpectDraw(FakeOpenGlBatcher& batcher, uint32_t line_count, uint32_t triang
                 uint32_t box_count) {
   batcher.ResetMockDrawCounts();
 
-  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+  for (const auto& group : batcher.GetNonEmptyRenderGroups()) {
     batcher.DrawRenderGroup(group);
   }
   EXPECT_EQ(batcher.GetDrawnLineColors().size(), line_count);
@@ -179,7 +179,7 @@ TEST(OpenGlBatcher, PickingSimpleElements) {
   batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255),
                        std::move(box_user_data));
 
-  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+  for (const auto& group : batcher.GetNonEmptyRenderGroups()) {
     batcher.DrawRenderGroup(group, true);
   }
 
@@ -210,7 +210,7 @@ TEST(OpenGlBatcher, MultipleDrawCalls) {
   batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255),
                        std::move(box_user_data));
 
-  for (auto& group : batcher.GetNonEmptyRenderGroups()) {
+  for (const auto& group : batcher.GetNonEmptyRenderGroups()) {
     batcher.DrawRenderGroup(group, true);
   }
 

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <memory>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/BatcherInterface.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/Geometry.h"
@@ -35,7 +36,7 @@ const Vec2 kArrowHeadSize{4, 2};
 class PrimitiveAssemblerTester : public PrimitiveAssembler {
  public:
   explicit PrimitiveAssemblerTester(PickingManager* picking_manager = nullptr)
-      : PrimitiveAssembler(&mock_batcher_, picking_manager) {}
+      : PrimitiveAssembler(&mock_batcher_, &state_manager_, picking_manager) {}
   [[nodiscard]] uint32_t GetNumLines() const { return mock_batcher_.GetNumLines(); }
   [[nodiscard]] uint32_t GetNumTriangles() const { return mock_batcher_.GetNumTriangles(); }
   [[nodiscard]] uint32_t GetNumBoxes() const { return mock_batcher_.GetNumBoxes(); }
@@ -46,6 +47,7 @@ class PrimitiveAssemblerTester : public PrimitiveAssembler {
 
  private:
   MockBatcher mock_batcher_;
+  BatchRenderGroupStateManager state_manager_;
 };
 
 }  // namespace

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -57,15 +57,18 @@ using orbit_gl::VariableTrack;
 
 TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, CaptureData* capture_data,
-                     PickingManager* picking_manager, TimeGraphLayout* time_graph_layout)
+                     PickingManager* picking_manager,
+                     orbit_gl::BatchRenderGroupStateManager* render_group_manager,
+                     TimeGraphLayout* time_graph_layout)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here and we save the
     // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
     : orbit_gl::CaptureViewElement(nullptr, viewport, time_graph_layout),
       accessible_parent_{parent},
+      text_renderer_static_(),
       layout_{time_graph_layout},
       batcher_(BatcherId::kTimeGraph),
-      primitive_assembler_(&batcher_, picking_manager),
+      primitive_assembler_(&batcher_, render_group_manager, picking_manager),
       thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
       capture_data_{capture_data},
       app_{app} {
@@ -935,10 +938,6 @@ void TimeGraph::DrawMarginsBetweenChildren(
       MakeBox(left_margin_slider_pos, Vec2(left_margin_width, slider_height));
   primitive_assembler.AddBox(left_margin_box_slider, GlCanvas::kZValueMargin,
                              GlCanvas::kBackgroundColor);
-}
-
-void TimeGraph::DrawText(QPainter* painter, float layer) {
-  text_renderer_static_.RenderLayer(painter, layer);
 }
 
 bool TimeGraph::IsFullyVisible(uint64_t min, uint64_t max) const {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -65,7 +65,6 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
     // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
     : orbit_gl::CaptureViewElement(nullptr, viewport, time_graph_layout),
       accessible_parent_{parent},
-      text_renderer_static_(),
       layout_{time_graph_layout},
       batcher_(BatcherId::kTimeGraph),
       primitive_assembler_(&batcher_, render_group_manager, picking_manager),

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -27,8 +27,9 @@ class UnitTestTimeGraph : public testing::Test {
     capture_data_ = TrackTestData::GenerateTestCaptureData();
     // Make the viewport big enough to account for a left margin.
     viewport_ = std::make_unique<Viewport>(1000, 200);
-    time_graph_ = std::make_unique<TimeGraph>(nullptr, nullptr, viewport_.get(),
-                                              capture_data_.get(), nullptr, &time_graph_layout_);
+    time_graph_ =
+        std::make_unique<TimeGraph>(nullptr, nullptr, viewport_.get(), capture_data_.get(), nullptr,
+                                    nullptr, &time_graph_layout_);
     time_graph_->ZoomAll();
   }
 

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <random>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CaptureViewElement.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/GlCanvas.h"
@@ -37,7 +38,7 @@ class TimelineUiTest : public TimelineUi {
   explicit TimelineUiTest(MockTimelineInfo* mock_timeline_info, Viewport* viewport,
                           TimeGraphLayout* layout)
       : TimelineUi(nullptr /*parent*/, mock_timeline_info, viewport, layout),
-        primitive_assembler_(&mock_batcher_),
+        primitive_assembler_(&mock_batcher_, &state_manager_),
         viewport_(viewport),
         mock_timeline_info_(mock_timeline_info) {
     viewport->SetWorldSize(viewport->GetWorldWidth(), TimelineUi::GetHeight());
@@ -143,6 +144,7 @@ class TimelineUiTest : public TimelineUi {
   PrimitiveAssembler primitive_assembler_;
   Viewport* viewport_;
   MockTimelineInfo* mock_timeline_info_;
+  BatchRenderGroupStateManager state_manager_;
 };
 
 static void TestUpdatePrimitivesWithSeveralRanges(int world_width) {

--- a/src/OrbitGl/include/OrbitGl/Batcher.h
+++ b/src/OrbitGl/include/OrbitGl/Batcher.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/BatcherInterface.h"
 #include "OrbitGl/PickingManager.h"
 #include "OrbitGl/TranslationStack.h"
@@ -32,19 +33,28 @@ class Batcher : public BatcherInterface {
     uint32_t draw_calls = 0;
     uint32_t stored_layers = 0;
     uint32_t stored_vertices = 0;
+
+    friend bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
+    friend bool operator!=(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
   };
 
   [[nodiscard]] virtual Statistics GetStatistics() const = 0;
-
-  friend bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
-  friend bool operator!=(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
+  [[nodiscard]] std::string GetCurrentRenderGroupName() const override {
+    return current_render_group_.name;
+  }
+  void SetCurrentRenderGroupName(std::string name) override {
+    current_render_group_.name = std::move(name);
+  }
 
  protected:
   orbit_gl::TranslationStack translations_;
+  BatchRenderGroupId current_render_group_;
 
  private:
   BatcherId batcher_id_;
 };
+
+[[nodiscard]] bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
 
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/include/OrbitGl/Batcher.h
+++ b/src/OrbitGl/include/OrbitGl/Batcher.h
@@ -54,8 +54,6 @@ class Batcher : public BatcherInterface {
   BatcherId batcher_id_;
 };
 
-[[nodiscard]] bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
-
 }  // namespace orbit_gl
 
 #endif  // ORBIT_GL_BATCHER_H_

--- a/src/OrbitGl/include/OrbitGl/BatcherInterface.h
+++ b/src/OrbitGl/include/OrbitGl/BatcherInterface.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_BATCHER_INTERFACE_H_
 
 #include "ClientProtos/capture_data.pb.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/Geometry.h"
 #include "OrbitGl/PickingManager.h"
 
@@ -26,7 +27,7 @@ struct PickingUserData {
 //
 // BatcherInterface is an interface class. By calling BatcherInterface::AddXXX, primitives are
 // added to internal CPU buffers, and sorted into layers formed by equal z-coordinates. Each layer
-// should then be drawn seperately with BatcherInterface::DrawLayer(). BatcherInterface also
+// should then be drawn seperately with BatcherInterface::DrawRenderGroup(). BatcherInterface also
 // provides a method to get the user data given a picking_id (in general used for tooltips).
 class BatcherInterface {
  public:
@@ -42,10 +43,13 @@ class BatcherInterface {
                            std::unique_ptr<PickingUserData> user_data) = 0;
   [[nodiscard]] virtual uint32_t GetNumElements() const = 0;
 
-  [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
-  virtual void DrawLayer(float layer, bool picking) = 0;
+  [[nodiscard]] virtual std::vector<BatchRenderGroupId> GetNonEmptyRenderGroups() const = 0;
+  virtual void DrawRenderGroup(const BatchRenderGroupId& group, bool picking) = 0;
 
   [[nodiscard]] virtual const PickingUserData* GetUserData(PickingId id) const = 0;
+
+  [[nodiscard]] virtual std::string GetCurrentRenderGroupName() const = 0;
+  virtual void SetCurrentRenderGroupName(std::string name) = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "OrbitGl/AccessibleInterfaceProvider.h"
-#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/PickingManager.h"
 #include "OrbitGl/PrimitiveAssembler.h"
@@ -118,6 +117,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void RequestUpdate(RequestUpdateScope scope = RequestUpdateScope::kDrawAndUpdatePrimitives);
 
   enum LayoutFlags : uint32_t { kNone = 0, kScaleHorizontallyWithParent = 1 << 0 };
+
   [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
   [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }
 
@@ -164,23 +164,12 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] virtual EventResult OnMouseEnter();
   [[nodiscard]] virtual EventResult OnMouseLeave();
 
-  [[nodiscard]] virtual bool RestrictDrawingToBody() const { return false; }
-
-  [[nodiscard]] uint32_t GetUid() const { return uid_; }
-
  private:
   bool is_mouse_over_ = false;
-  uint32_t uid_;
-
-  std::string previous_batcher_render_group_name_{BatchRenderGroupId::kGlobalGroup};
-  std::string previous_text_render_group_name_{BatchRenderGroupId::kGlobalGroup};
 
   float width_ = 0.;
   Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;
-
-  void PreRender(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer);
-  void PostRender(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer);
 
   friend class CaptureViewElementTester;
 };

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "OrbitGl/AccessibleInterfaceProvider.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/PickingManager.h"
 #include "OrbitGl/PrimitiveAssembler.h"
@@ -117,7 +118,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void RequestUpdate(RequestUpdateScope scope = RequestUpdateScope::kDrawAndUpdatePrimitives);
 
   enum LayoutFlags : uint32_t { kNone = 0, kScaleHorizontallyWithParent = 1 << 0 };
-
   [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
   [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }
 
@@ -164,12 +164,23 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] virtual EventResult OnMouseEnter();
   [[nodiscard]] virtual EventResult OnMouseLeave();
 
+  [[nodiscard]] virtual bool RestrictDrawingToBody() const { return false; }
+
+  [[nodiscard]] uint32_t GetUid() const { return uid_; }
+
  private:
   bool is_mouse_over_ = false;
+  uint32_t uid_;
+
+  std::string previous_batcher_render_group_name_{BatchRenderGroupId::kGlobalGroup};
+  std::string previous_text_render_group_name_{BatchRenderGroupId::kGlobalGroup};
 
   float width_ = 0.;
   Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;
+
+  void PreRender(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer);
+  void PostRender(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer);
 
   friend class CaptureViewElementTester;
 };

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElementTester.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_CAPTURE_VIEW_ELEMENT_TESTER_H_
 #define ORBIT_GL_CAPTURE_VIEW_ELEMENT_TESTER_H_
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CaptureViewElement.h"
 #include "OrbitGl/MockBatcher.h"
 #include "OrbitGl/MockTextRenderer.h"
@@ -73,6 +74,7 @@ class CaptureViewElementTester {
   MockBatcher batcher_;
   MockTextRenderer text_renderer_;
   PickingManager picking_manager_;
+  BatchRenderGroupStateManager state_manager_;
 
   PrimitiveAssembler primitive_assembler_;
 };

--- a/src/OrbitGl/include/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureWindow.h
@@ -74,7 +74,6 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
 
   void RenderAllLayers(QPainter* painter);
 
-  virtual void RenderText(QPainter* painter, float layer);
   virtual bool ShouldSkipRendering() const;
 
   virtual void ToggleRecording();
@@ -110,6 +109,9 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
 
  private:
   TimeGraphLayout* time_graph_layout_ = nullptr;
+
+  void DrawLayerDebugInfo(const std::vector<orbit_gl::BatchRenderGroupId>& sorted_groups,
+                          QPainter* painter);
 };
 
 #endif  // ORBIT_GL_CAPTURE_WINDOW_H_

--- a/src/OrbitGl/include/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/include/OrbitGl/GlCanvas.h
@@ -119,6 +119,8 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   PickingMode picking_mode_ = PickingMode::kNone;
   bool draw_as_if_picking_ = false;
 
+  orbit_gl::BatchRenderGroupStateManager render_group_manager_;
+
   double ref_time_click_{0.0};
   float track_container_click_scrolling_offset_ = 0;
   orbit_gl::QtTextRenderer text_renderer_;

--- a/src/OrbitGl/include/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/include/OrbitGl/IntrospectionWindow.h
@@ -36,7 +36,6 @@ class IntrospectionWindow : public CaptureWindow {
 
  protected:
   void Draw(QPainter* painter) override;
-  void RenderText(QPainter* painter, float layer) override;
   bool ShouldSkipRendering() const override { return false; };
 
  private:

--- a/src/OrbitGl/include/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/MockBatcher.h
@@ -14,14 +14,17 @@
 #include <limits>
 #include <memory>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/Batcher.h"
 #include "OrbitGl/BatcherInterface.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/Geometry.h"
 #include "OrbitGl/PickingManager.h"
 #include "absl/container/btree_map.h"
+#include "absl/container/flat_hash_set.h"
 
 namespace orbit_gl {
 
@@ -40,11 +43,11 @@ class MockBatcher : public Batcher {
   void ResetElements() override;
   [[nodiscard]] uint32_t GetNumElements() const override;
 
-  [[nodiscard]] std::vector<float> GetLayers() const override {
-    return std::vector<float>(z_layers_.begin(), z_layers_.end());
+  [[nodiscard]] std::vector<BatchRenderGroupId> GetNonEmptyRenderGroups() const override {
+    return std::vector<BatchRenderGroupId>(render_groups_.begin(), render_groups_.end());
   }
 
-  void DrawLayer(float /*layer*/, bool /*picking*/) override {}
+  void DrawRenderGroup(const BatchRenderGroupId& /*group*/, bool /*picking*/) override {}
 
   [[nodiscard]] Statistics GetStatistics() const override { return {}; }
 
@@ -67,12 +70,14 @@ class MockBatcher : public Batcher {
 
   Vec2 min_point_;
   Vec2 max_point_;
-  std::set<float> z_layers_;
+  absl::flat_hash_set<BatchRenderGroupId> render_groups_;
   int num_vertical_lines_ = 0;
   int num_horizontal_lines_ = 0;
   absl::btree_map<Color, int> num_lines_by_color_;
   absl::btree_map<Color, int> num_triangles_by_color_;
   absl::btree_map<Color, int> num_boxes_by_color_;
+
+  BatchRenderGroupStateManager owned_manager_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/MockBatcher.h
@@ -23,7 +23,6 @@
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/Geometry.h"
 #include "OrbitGl/PickingManager.h"
-#include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_set.h"
 
 namespace orbit_gl {
@@ -44,7 +43,7 @@ class MockBatcher : public Batcher {
   [[nodiscard]] uint32_t GetNumElements() const override;
 
   [[nodiscard]] std::vector<BatchRenderGroupId> GetNonEmptyRenderGroups() const override {
-    return std::vector<BatchRenderGroupId>(render_groups_.begin(), render_groups_.end());
+    return {render_groups_.begin(), render_groups_.end()};
   }
 
   void DrawRenderGroup(const BatchRenderGroupId& /*group*/, bool /*picking*/) override {}

--- a/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_MOCK_TEXT_RENDERER_H_
 #define ORBIT_GL_MOCK_TEXT_RENDERER_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <gmock/gmock.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -13,8 +15,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/TextRenderer.h"
 
@@ -27,9 +31,11 @@ class MockTextRenderer : public TextRenderer {
   MOCK_METHOD(void, Init, (), (override));
   void Clear() override;
 
-  MOCK_METHOD(void, RenderLayer, (QPainter*, float), (override));
-  [[nodiscard]] std::vector<float> GetLayers() const override {
-    return std::vector<float>(z_layers_.begin(), z_layers_.end());
+  MOCK_METHOD(void, DrawRenderGroup,
+              (QPainter*, BatchRenderGroupStateManager& state_manager, const BatchRenderGroupId&),
+              (override));
+  [[nodiscard]] std::vector<BatchRenderGroupId> GetRenderGroups() const override {
+    return {render_groups_.begin(), render_groups_.end()};
   }
 
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting) override;
@@ -60,7 +66,7 @@ class MockTextRenderer : public TextRenderer {
 
   Vec2 min_point_;
   Vec2 max_point_;
-  std::set<float> z_layers_;
+  absl::flat_hash_set<BatchRenderGroupId> render_groups_;
   std::set<uint32_t> num_characters_in_add_text_;
   std::set<float> vertical_position_in_add_text;
   int num_add_text_calls_ = 0;

--- a/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/CoreMath.h"
 #include "OrbitGl/TextRenderer.h"
 #include "OrbitGl/TextRendererInterface.h"
@@ -25,10 +26,14 @@ namespace orbit_gl {
 class QtTextRenderer : public TextRenderer {
  public:
   void Init() override{};
-  void Clear() override { stored_text_.clear(); };
+  void Clear() override {
+    stored_text_.clear();
+    current_render_group_ = BatchRenderGroupId();
+  };
 
-  void RenderLayer(QPainter* painter, float layer) override;
-  [[nodiscard]] std::vector<float> GetLayers() const override;
+  [[nodiscard]] std::vector<BatchRenderGroupId> GetRenderGroups() const override;
+  void DrawRenderGroup(QPainter* painter, BatchRenderGroupStateManager& manager,
+                       const BatchRenderGroupId& group) override;
 
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting) override;
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
@@ -66,7 +71,7 @@ class QtTextRenderer : public TextRenderer {
     int h = 0;
     TextFormatting formatting;
   };
-  absl::flat_hash_map<float, std::vector<StoredText>> stored_text_;
+  absl::flat_hash_map<BatchRenderGroupId, std::vector<StoredText>> stored_text_;
   absl::flat_hash_map<uint32_t, float> minimum_string_width_cache_;
   absl::flat_hash_map<uint32_t, CharacterWidthLookup> character_width_lookup_cache_;
   absl::flat_hash_map<uint32_t, int> single_line_height_cache_;

--- a/src/OrbitGl/include/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/TextRenderer.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_TEXT_RENDERER_H_
 #define ORBIT_GL_TEXT_RENDERER_H_
 
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/TextRendererInterface.h"
 #include "OrbitGl/Viewport.h"
 
@@ -17,10 +18,18 @@ class TextRenderer : public TextRendererInterface {
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }
   void PopTranslation() { translations_.PopTranslation(); }
 
+  void SetCurrentRenderGroupName(std::string name) override {
+    current_render_group_.name = std::move(name);
+  }
+  [[nodiscard]] std::string GetCurrentRenderGroupName() const override {
+    return current_render_group_.name;
+  }
+
  protected:
   Viewport* viewport_ = nullptr;
 
   TranslationStack translations_;
+  BatchRenderGroupId current_render_group_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
@@ -33,8 +33,12 @@ class TextRendererInterface {
   virtual void Init() = 0;
   virtual void Clear() = 0;
 
-  virtual void RenderLayer(QPainter* painter, float layer) = 0;
-  [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
+  [[nodiscard]] virtual std::vector<BatchRenderGroupId> GetRenderGroups() const = 0;
+  virtual void DrawRenderGroup(QPainter* painter, BatchRenderGroupStateManager& manager,
+                               const BatchRenderGroupId& group) = 0;
+
+  [[nodiscard]] virtual std::string GetCurrentRenderGroupName() const = 0;
+  virtual void SetCurrentRenderGroupName(std::string name) = 0;
 
   // Add a - potentially multiline - text at the given position and z-layer and with the specifier
   // formatting. If formatting.max_size is set all lines are elided to fit into this width.

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -28,6 +28,7 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "OrbitGl/AccessibleInterfaceProvider.h"
+#include "OrbitGl/BatchRenderGroup.h"
 #include "OrbitGl/Batcher.h"
 #include "OrbitGl/Button.h"
 #include "OrbitGl/CaptureViewElement.h"
@@ -55,13 +56,14 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,
-                     PickingManager* picking_manager, TimeGraphLayout* time_graph_layout);
+                     PickingManager* picking_manager,
+                     orbit_gl::BatchRenderGroupStateManager* render_group_manager,
+                     TimeGraphLayout* time_graph_layout);
 
   [[nodiscard]] float GetHeight() const override;
 
   void DrawAllElements(orbit_gl::PrimitiveAssembler& primitive_assembler,
                        orbit_gl::TextRenderer& text_renderer, PickingMode& picking_mode);
-  void DrawText(QPainter* painter, float layer);
 
   // TODO(b/214282122): Move Process Timers function outside the UI.
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info);


### PR DESCRIPTION
This replaces the layers, previously only defined by z-values,
with `BatchRenderGroupId`. The Batcher now uses those to
group primitives into draw calls, and applies the requested
clipping area if any is given.

This PR does not yet change any behavior in `CaptureViewElement`
and there is no change in existing groups. All stencils stay disabled
for now, so this should not have any visual not performance
impact.

Comparison of visuals & rendering times:
[Before](https://screenshot.googleplex.com/3hA9PCBALNP8Ub2) - [After](https://screenshot.googleplex.com/hQEFWtwYd5TwQRy).

The performance numbers have to be taken with a grain of salt,
as they do fluctuate quite a bit. Some performance regression is
likely expected as the hash of `BatchRenderGroupId` is not as
cheap as the old float-hash. 