### PR TITLE
Make TimeoutOr a Result type

### DIFF
--- a/src/QtUtils/CreateTimeoutTest.cpp
+++ b/src/QtUtils/CreateTimeoutTest.cpp
@@ -13,8 +13,11 @@
 
 #include "OrbitBase/Future.h"
 #include "OrbitBase/ImmediateExecutor.h"
+#include "OrbitBase/Promise.h"
 #include "OrbitBase/WhenAll.h"
+#include "QtTestUtils/WaitFor.h"
 #include "QtUtils/CreateTimeout.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_qt_utils {
 
@@ -37,6 +40,7 @@ TEST(CreateTimeout, TimeoutCompletesEventually) {
 
 TEST(CreateTimeout, ParallelTimeoutsDontDeadlock) {
   std::vector<orbit_base::Future<Timeout>> timeouts;
+  timeouts.reserve(10);
   for (int i = 0; i < 10; ++i) {
     timeouts.emplace_back(CreateTimeout(std::chrono::milliseconds{10 + i}));
   }
@@ -59,4 +63,39 @@ TEST(CreateTimeout, MaintainsMinimumWaitTime) {
     EXPECT_GE(std::chrono::steady_clock::now(), start + duration);
   }
 }
+
+TEST(WhenValueOrTimeout, ValueCompletesBeforeTimeoutVoid) {
+  orbit_base::Promise<void> promise{};
+
+  // Schedule a task on the main thread event loop - being executed in 10ms
+  QTimer::singleShot(std::chrono::milliseconds{10}, [&]() { promise.MarkFinished(); });
+
+  orbit_base::Future<TimeoutOr<void>> value_or_timeout =
+      WhenValueOrTimeout(promise.GetFuture(), std::chrono::milliseconds{100});
+  WaitForFutureToComplete(value_or_timeout);
+  EXPECT_THAT(value_or_timeout.Get(), orbit_test_utils::HasNoError());
+}
+
+TEST(WhenValueOrTimeout, ValueCompletesBeforeTimeoutInt) {
+  orbit_base::Promise<int> promise{};
+
+  // Schedule a task on the main thread event loop - being executed in 10us
+  QTimer::singleShot(std::chrono::milliseconds{10}, [&]() { promise.SetResult(42); });
+
+  orbit_base::Future<TimeoutOr<int>> value_or_timeout =
+      WhenValueOrTimeout(promise.GetFuture(), std::chrono::milliseconds{100});
+  WaitForFutureToComplete(value_or_timeout);
+  EXPECT_THAT(value_or_timeout.Get(), orbit_test_utils::HasValue(42));
+}
+
+TEST(WhenValueOrTimeout, OperationTimesOutBeforeValue) {
+  // This promise will never complete.
+  orbit_base::Promise<void> promise{};
+
+  orbit_base::Future<TimeoutOr<void>> value_or_timeout =
+      WhenValueOrTimeout(promise.GetFuture(), std::chrono::milliseconds{10});
+  WaitForFutureToComplete(value_or_timeout);
+  EXPECT_THAT(value_or_timeout.Get(), orbit_test_utils::HasError());
+}
+
 }  // namespace orbit_qt_utils


### PR DESCRIPTION
Similar to `Canceled` and `NotFound`, `Timeout` now becomes a result type and `TimeoutOr<T>` an alias for `Result<T, Timeout>`.

This also adds a helper function `WhenValueOrTimeout` which is a wrapper around `orbit_base::WhenAny`. But `WhenAny` returns a generic `std::variant<T, Timeout>` so, there is some glue code which converts it into a `Result,<T, Timeout>`.