### PR TITLE
Deactivate thread bar based on selections

### DIFF
--- a/src/OrbitGl/GlUtilsTest.cpp
+++ b/src/OrbitGl/GlUtilsTest.cpp
@@ -32,3 +32,10 @@ TEST(GlUtils, TicksToMicroseconds) {
   EXPECT_TRUE(abs(dt0 - 1.0) < kEpsilon);
   EXPECT_TRUE(abs(dt1 - 2.0) < kEpsilon);
 }
+
+TEST(GlUtils, TicksToMicrosecondsNegative) {
+  uint64_t t0 = 0;
+  uint64_t t1 = 2000;
+  EXPECT_TRUE(TicksToMicroseconds(t0, t1) > 0);
+  EXPECT_TRUE(TicksToMicroseconds(t1, t0) < 0);
+}

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -49,6 +49,7 @@
 #include "CaptureFile/CaptureFileHelpers.h"
 #include "ClientData/CallstackData.h"
 #include "ClientData/CallstackInfo.h"
+#include "ClientData/CallstackType.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
 #include "ClientData/PostProcessedSamplingData.h"
@@ -2154,6 +2155,16 @@ bool OrbitApp::IsTimerActive(const TimerInfo& timer) const {
     return false;
   }
   return data_manager_->IsScopeVisible(scope_id.value());
+}
+
+std::optional<TimeRange> OrbitApp::GetActiveTimeRangeForTid(ThreadID thread_id) const {
+  ThreadID selected_tid = data_manager_->selected_thread_id();
+  if (selected_tid != kAllProcessThreadsTid && selected_tid != thread_id) {
+    return std::nullopt;
+  }
+  std::optional<TimeRange> time_range_selection = data_manager_->GetSelectionTimeRange();
+  // If no selection is active, then the entire thread should be active.
+  return time_range_selection.has_value() ? time_range_selection.value() : kDefaultTimeRange;
 }
 
 std::optional<ScopeId> OrbitApp::GetHighlightedScopeId() const {

--- a/src/OrbitGl/include/OrbitGl/GlUtils.h
+++ b/src/OrbitGl/include/OrbitGl/GlUtils.h
@@ -13,7 +13,7 @@
 }
 
 [[nodiscard]] inline double TicksToMicroseconds(uint64_t start, uint64_t end) {
-  return static_cast<double>(end - start) * 0.001;
+  return (static_cast<double>(end) - static_cast<double>(start)) * 0.001;
 }
 
 #endif  // ORBIT_GL_GL_UTILS_H_

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -367,6 +367,10 @@ class OrbitApp final : public DataViewFactory,
 
   void SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids) override;
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const;
+  // Returns the time range for which thread_id is active. If the entire thread is inactive, it will
+  // return nullopt.
+  std::optional<orbit_client_data::TimeRange> GetActiveTimeRangeForTid(
+      orbit_client_data::ThreadID thread_id) const;
 
   [[nodiscard]] std::optional<ScopeId> GetHighlightedScopeId() const override;
   void SetHighlightedScopeId(std::optional<ScopeId> highlighted_scope_id) override;


### PR DESCRIPTION
This change makes the thread bars gray when another thread is selected or when it is outside of the time range.  I also changed TicksToMicroseconds to make it possible to be negative if the time given was before the start of the capture.

Screenshot: https://screenshot.googleplex.com/9i3ZXgcDQo9rUjT

Bug: http://b/240111360