### PR TITLE
Make the GraphTrack a non-tempate class

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -16,8 +16,8 @@
 
 namespace orbit_gl {
 
-[[nodiscard]] static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
-    std::string_view cgroup_name, std::string_view process_name) {
+[[nodiscard]] static std::vector<std::string> CreateSeriesName(std::string_view cgroup_name,
+                                                               std::string_view process_name) {
   return {absl::StrFormat("Process [%s]", process_name),
           absl::StrFormat("CGroup [%s]", cgroup_name), "System"};
 }
@@ -46,16 +46,16 @@ BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent,
                                               // rendering time when we do aggregation.
 }
 
-void BasicPageFaultsTrack::AddValues(
-    uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values) {
+void BasicPageFaultsTrack::AddValues(uint64_t timestamp_ns, absl::Span<const double> values) {
   if (previous_time_and_values_.has_value()) {
-    std::array<double, kBasicPageFaultsTrackDimension> differences{};
+    std::vector<double> differences(kBasicPageFaultsTrackDimension);
     std::transform(values.begin(), values.end(), previous_time_and_values_.value().second.begin(),
                    differences.begin(), std::minus<double>());
     series_.AddValues(previous_time_and_values_.value().first, differences);
   }
 
-  previous_time_and_values_ = std::make_pair(timestamp_ns, values);
+  previous_time_and_values_ =
+      std::make_pair(timestamp_ns, std::vector(values.begin(), values.end()));
 }
 
 void BasicPageFaultsTrack::AddValuesAndUpdateAnnotations(

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -43,14 +43,13 @@ CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.
-  const std::array<Color, kCGroupAndProcessMemoryTrackDimension>
-      c_group_and_process_memory_traccolors{
-          Color(231, 68, 53, 255),    // red
-          Color(185, 117, 181, 255),  // purple
-          Color(246, 196, 0, 255),    // orange
-          Color(87, 166, 74, 255)     // green
-      };
-  SetSeriesColors(c_group_and_process_memory_traccolors);
+  std::vector<Color> c_group_and_process_memory_track_colors{
+      Color(231, 68, 53, 255),    // red
+      Color(185, 117, 181, 255),  // purple
+      Color(246, 196, 0, 255),    // orange
+      Color(87, 166, 74, 255)     // green
+  };
+  SetSeriesColors(std::move(c_group_and_process_memory_track_colors));
 
   const std::string value_lower_bound_label = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -112,7 +112,7 @@ Color GraphTrack::GetColor(size_t index) const {
 
 float GraphTrack::GetGraphContentHeight() const {
   float result = layout_->GetTextBoxHeight() * kBoxHeightMultiplier;
-  if (!IsCollapsed()) result *= series_.GetDimension();
+  if (!IsCollapsed()) result *= static_cast<float>(series_.GetDimension());
 
   return result;
 }
@@ -127,7 +127,7 @@ std::string GraphTrack::GetLabelTextFromValues(absl::Span<const double> values) 
   std::string value_unit = series_.GetValueUnit();
   std::string text;
   std::string_view delimiter = "";
-  for (int i = series_.GetDimension() - 1; i >= 0; i--) {
+  for (int i = static_cast<int>(series_.GetDimension()) - 1; i >= 0; i--) {
     std::string formatted_name =
         series_names.at(i).empty() ? "" : absl::StrFormat("%s: ", series_names.at(i));
     std::string formatted_value =

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -35,8 +35,7 @@ namespace orbit_gl {
 }
 
 template <size_t Dimension>
-float LineGraphTrack<Dimension>::GetLabelYFromValues(
-    const std::array<double, Dimension>& values) const {
+float LineGraphTrack<Dimension>::GetLabelYFromValues(absl::Span<const double> values) const {
   float content_height = this->GetGraphContentHeight();
   float base_y = this->GetGraphContentBottomY();
   double min = this->GetGraphMinValue();

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -18,15 +18,15 @@ void MemoryTrack<Dimension>::DoUpdatePrimitives(PrimitiveAssembler& primitive_as
                                                 TextRenderer& text_renderer, uint64_t min_tick,
                                                 uint64_t max_tick, PickingMode picking_mode) {
   ORBIT_SCOPE_WITH_COLOR("MemoryTrack<Dimension>::DoUpdatePrimitives", kOrbitColorGrey);
-  GraphTrack<Dimension>::DoUpdatePrimitives(primitive_assembler, text_renderer, min_tick, max_tick,
-                                            picking_mode);
+  GraphTrack::DoUpdatePrimitives(primitive_assembler, text_renderer, min_tick, max_tick,
+                                 picking_mode);
 }
 
 template <size_t Dimension>
 void MemoryTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
                                     TextRenderer& text_renderer,
                                     const CaptureViewElement::DrawContext& draw_context) {
-  GraphTrack<Dimension>::DoDraw(primitive_assembler, text_renderer, draw_context);
+  GraphTrack::DoDraw(primitive_assembler, text_renderer, draw_context);
 
   if (this->IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(primitive_assembler, text_renderer, this->layout_,
@@ -35,7 +35,7 @@ void MemoryTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
 
 template <size_t Dimension>
 void MemoryTrack<Dimension>::TrySetValueUpperBound(std::string pretty_label, double raw_value) {
-  double max_series_value = GraphTrack<Dimension>::GetGraphMaxValue();
+  double max_series_value = GraphTrack::GetGraphMaxValue();
   if (raw_value < max_series_value) {
     ORBIT_LOG("Fail to set MemoryTrack value upper bound: input value %f < maximum series value %f",
               raw_value, max_series_value);
@@ -46,7 +46,7 @@ void MemoryTrack<Dimension>::TrySetValueUpperBound(std::string pretty_label, dou
 
 template <size_t Dimension>
 void MemoryTrack<Dimension>::TrySetValueLowerBound(std::string pretty_label, double raw_value) {
-  double min_series_value = GraphTrack<Dimension>::GetGraphMinValue();
+  double min_series_value = GraphTrack::GetGraphMinValue();
   if (raw_value > min_series_value) {
     ORBIT_LOG("Fail to set MemoryTrack value lower bound: input value %f > minimum series value %f",
               raw_value, min_series_value);
@@ -58,21 +58,19 @@ void MemoryTrack<Dimension>::TrySetValueLowerBound(std::string pretty_label, dou
 template <size_t Dimension>
 double MemoryTrack<Dimension>::GetGraphMaxValue() const {
   if (!this->GetValueUpperBound().has_value()) {
-    return GraphTrack<Dimension>::GetGraphMaxValue();
+    return GraphTrack::GetGraphMaxValue();
   }
 
-  return std::max(GraphTrack<Dimension>::GetGraphMaxValue(),
-                  this->GetValueUpperBound().value().second);
+  return std::max(GraphTrack::GetGraphMaxValue(), this->GetValueUpperBound().value().second);
 }
 
 template <size_t Dimension>
 double MemoryTrack<Dimension>::GetGraphMinValue() const {
   if (!this->GetValueLowerBound().has_value()) {
-    return GraphTrack<Dimension>::GetGraphMinValue();
+    return GraphTrack::GetGraphMinValue();
   }
 
-  return std::min(GraphTrack<Dimension>::GetGraphMinValue(),
-                  this->GetValueLowerBound().value().second);
+  return std::min(GraphTrack::GetGraphMinValue(), this->GetValueLowerBound().value().second);
 }
 
 template class MemoryTrack<1>;

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -36,12 +36,12 @@ SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent,
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.
-  const std::array<Color, kSystemMemoryTrackDimension> system_memory_track_colors{
+  std::vector<Color> system_memory_track_colors{
       Color(231, 68, 53, 255),  // red
       Color(246, 196, 0, 255),  // orange
       Color(87, 166, 74, 255)   // green
   };
-  SetSeriesColors(system_memory_track_colors);
+  SetSeriesColors(std::move(system_memory_track_colors));
 
   const std::string value_lower_bound_label = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;

--- a/src/OrbitGl/include/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/include/OrbitGl/BasicPageFaultsTrack.h
@@ -46,8 +46,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   // unknown type.
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kUnknown; }
 
-  void AddValues(uint64_t timestamp_ns,
-                 const std::array<double, kBasicPageFaultsTrackDimension>& values) override;
+  void AddValues(uint64_t timestamp_ns, absl::Span<const double> values) override;
   void AddValuesAndUpdateAnnotations(
       uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values);
 
@@ -79,8 +78,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   }
 
   Track* parent_;
-  std::optional<std::pair<uint64_t, std::array<double, kBasicPageFaultsTrackDimension>>>
-      previous_time_and_values_ = std::nullopt;
+  std::optional<std::pair<uint64_t, std::vector<double>>> previous_time_and_values_ = std::nullopt;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/include/OrbitGl/GraphTrack.h
@@ -56,8 +56,8 @@ class GraphTrack : public Track {
   [[nodiscard]] uint64_t GetMinTime() const override;
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
-  void SetSeriesColors(absl::Span<const Color> series_colors) {
-    series_colors_ = std::vector(series_colors.begin(), series_colors.end());
+  void SetSeriesColors(std::vector<Color> series_colors) {
+    series_colors_ = std::move(series_colors);
   }
 
   // These are not supported in GraphTracks

--- a/src/OrbitGl/include/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/include/OrbitGl/GraphTrack.h
@@ -10,7 +10,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <array>
 #include <cmath>
 #include <map>
 #include <optional>
@@ -32,14 +31,13 @@
 #include "OrbitGl/Track.h"
 #include "OrbitGl/Viewport.h"
 
-template <size_t Dimension>
 class GraphTrack : public Track {
  public:
   explicit GraphTrack(CaptureViewElement* parent,
                       const orbit_gl::TimelineInfoInterface* timeline_info,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                      std::array<std::string, Dimension> series_names,
-                      uint8_t series_value_decimal_digits, std::string series_value_unit,
+                      std::vector<std::string> series_names, uint8_t series_value_decimal_digits,
+                      std::string series_value_unit,
                       const orbit_client_data::ModuleManager* module_manager,
                       const orbit_client_data::CaptureData* capture_data);
 
@@ -51,15 +49,15 @@ class GraphTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] bool IsEmpty() const override { return series_.IsEmpty(); }
 
-  virtual void AddValues(uint64_t timestamp_ns, const std::array<double, Dimension>& values) {
+  virtual void AddValues(uint64_t timestamp_ns, absl::Span<const double> values) {
     series_.AddValues(timestamp_ns, values);
   }
 
   [[nodiscard]] uint64_t GetMinTime() const override;
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
-  void SetSeriesColors(const std::array<Color, Dimension>& series_colors) {
-    series_colors_ = series_colors;
+  void SetSeriesColors(absl::Span<const Color> series_colors) {
+    series_colors_ = std::vector(series_colors.begin(), series_colors.end());
   }
 
   // These are not supported in GraphTracks
@@ -101,10 +99,8 @@ class GraphTrack : public Track {
   }
   [[nodiscard]] float GetGraphContentHeight() const;
 
-  [[nodiscard]] virtual float GetLabelYFromValues(
-      const std::array<double, Dimension>& values) const;
-  [[nodiscard]] virtual std::string GetLabelTextFromValues(
-      const std::array<double, Dimension>& values) const;
+  [[nodiscard]] virtual float GetLabelYFromValues(absl::Span<const double> values) const;
+  [[nodiscard]] virtual std::string GetLabelTextFromValues(absl::Span<const double> values) const;
   [[nodiscard]] uint32_t GetLegendFontSize(uint32_t indentation_level = 0) const;
 
   virtual void DrawMouseLabel(orbit_gl::PrimitiveAssembler& primitive_assembler,
@@ -131,7 +127,7 @@ class GraphTrack : public Track {
                              absl::Span<const float> normalized_cumulative_values, float z);
   [[nodiscard]] bool HasLegend() const;
 
-  std::optional<std::array<Color, Dimension>> series_colors_;
+  std::vector<Color> series_colors_;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/include/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/include/OrbitGl/LineGraphTrack.h
@@ -22,14 +22,13 @@ namespace orbit_gl {
 // This is an implementation of the `GraphTrack` to visualize the `MultivariateTimeSeries` data in a
 // multi-line stairstep graph.
 template <size_t Dimension>
-class LineGraphTrack : public GraphTrack<Dimension> {
+class LineGraphTrack : public GraphTrack {
  public:
-  using GraphTrack<Dimension>::GraphTrack;
+  using GraphTrack::GraphTrack;
   ~LineGraphTrack() override = default;
 
  protected:
-  [[nodiscard]] float GetLabelYFromValues(
-      const std::array<double, Dimension>& values) const override;
+  [[nodiscard]] float GetLabelYFromValues(absl::Span<const double> values) const override;
   void DrawSeries(PrimitiveAssembler& primitive_assembler, uint64_t min_tick, uint64_t max_tick,
                   float z) override;
   virtual void DrawSingleSeriesEntry(PrimitiveAssembler& primitive_assembler, uint64_t start_tick,

--- a/src/OrbitGl/include/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/include/OrbitGl/MemoryTrack.h
@@ -29,7 +29,7 @@
 namespace orbit_gl {
 
 template <size_t Dimension>
-class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
+class MemoryTrack : public GraphTrack, public AnnotationTrack {
  public:
   explicit MemoryTrack(CaptureViewElement* parent,
                        const orbit_gl::TimelineInfoInterface* timeline_info,
@@ -38,9 +38,10 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
                        uint8_t series_value_decimal_digits, std::string series_value_units,
                        const orbit_client_data::ModuleManager* module_manager,
                        const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, timeline_info, viewport, layout, series_names,
-                              series_value_decimal_digits, std::move(series_value_units),
-                              module_manager, capture_data),
+      : GraphTrack(parent, timeline_info, viewport, layout,
+                   std::vector(series_names.begin(), series_names.end()),
+                   series_value_decimal_digits, std::move(series_value_units), module_manager,
+                   capture_data),
         AnnotationTrack() {
     // Memory tracks are collapsed by default.
     this->SetCollapsed(true);

--- a/src/OrbitGl/include/OrbitGl/MultivariateTimeSeries.h
+++ b/src/OrbitGl/include/OrbitGl/MultivariateTimeSeries.h
@@ -31,6 +31,7 @@ class MultivariateTimeSeries {
   [[nodiscard]] std::string GetValueUnit() const { return value_unit_; }
   [[nodiscard]] double GetMin() const;
   [[nodiscard]] double GetMax() const;
+  [[nodiscard]] size_t GetDimension() const { return series_names_.size(); }
 
   [[nodiscard]] bool IsEmpty() const;
   [[nodiscard]] size_t GetTimeToSeriesValuesSize() const;
@@ -64,6 +65,7 @@ class MultivariateTimeSeries {
   double min_ ABSL_GUARDED_BY(mutex_) = std::numeric_limits<double>::max();
   double max_ ABSL_GUARDED_BY(mutex_) = std::numeric_limits<double>::lowest();
 
+  // Should NOT be modified after construction.
   std::vector<std::string> series_names_;
   uint8_t value_decimal_digits_;
   std::string value_unit_;

--- a/src/OrbitGl/include/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/include/OrbitGl/VariableTrack.h
@@ -15,7 +15,6 @@
 namespace orbit_gl {
 
 constexpr size_t kVariableTrackDimension = 1;
-const std::array<Color, kVariableTrackDimension> kVariableTrackColor{Color(0, 128, 255, 128)};
 
 class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
   static constexpr uint8_t kTrackValueDecimalDigits = 6;
@@ -32,7 +31,8 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
                                                 kTrackValueDecimalDigits, kTrackValueUnits,
                                                 module_manager, capture_data),
         name_{std::move(name)} {
-    SetSeriesColors(kVariableTrackColor);
+    std::vector<Color> variable_track_color{Color(0, 128, 255, 128)};
+    SetSeriesColors(std::move(variable_track_color));
   }
 
   [[nodiscard]] bool IsCollapsible() const override { return false; }

--- a/src/OrbitGl/include/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/include/OrbitGl/VariableTrack.h
@@ -28,7 +28,7 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
                          const orbit_client_data::ModuleManager* module_manager,
                          const orbit_client_data::CaptureData* capture_data)
       : LineGraphTrack<kVariableTrackDimension>(parent, timeline_info, viewport, layout,
-                                                std::array<std::string, kVariableTrackDimension>{},
+                                                std::vector<std::string>(kVariableTrackDimension),
                                                 kTrackValueDecimalDigits, kTrackValueUnits,
                                                 module_manager, capture_data),
         name_{std::move(name)} {


### PR DESCRIPTION
3nd step to make `GraphTrack`s not templated based on the data series Dimension.

Bug: #4534
Test: unit tests; open a capture with memory tracks and variable tracks