### PR TITLE
Rename HasError to HasErrorWithMessage

### DIFF
--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -33,7 +33,7 @@
 
 namespace orbit_capture_file {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 
@@ -219,7 +219,7 @@ TEST_F(CaptureFileTest, CreateCaptureFileWriteAdditionalSectionAndReadMainSectio
     ClientCaptureEvent event;
     ErrorMessageOr<void> error = capture_section->ReadMessage(&event);
     if (error.has_error()) {
-      ASSERT_THAT(error, HasError("Unexpected end of section"));
+      ASSERT_THAT(error, HasErrorWithMessage("Unexpected end of section"));
       return;
     }
     ASSERT_EQ(0, event.ByteSizeLong());
@@ -309,14 +309,14 @@ TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSignature) {
       HasNoError());
 
   auto capture_file_or_error = CaptureFile::OpenForReadWrite(GetCaptureFilePath());
-  EXPECT_THAT(capture_file_or_error, HasError("Invalid file signature"));
+  EXPECT_THAT(capture_file_or_error, HasErrorWithMessage("Invalid file signature"));
 }
 
 TEST_F(CaptureFileHeaderTest, OpenCaptureFileTooSmall) {
   EXPECT_THAT(orbit_base::WriteStringToFile(GetCaptureFilePath(), "ups"), HasNoError());
 
   auto capture_file_or_error = CaptureFile::OpenForReadWrite(GetCaptureFilePath());
-  EXPECT_THAT(capture_file_or_error, HasError("Failed to read the file signature"));
+  EXPECT_THAT(capture_file_or_error, HasErrorWithMessage("Failed to read the file signature"));
 }
 
 static std::string CreateHeader(uint32_t version, uint64_t capture_section_offset,
@@ -337,7 +337,7 @@ TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidVersion) {
   EXPECT_THAT(orbit_base::WriteStringToFile(GetCaptureFilePath(), header), HasNoError());
 
   auto capture_file_or_error = CaptureFile::OpenForReadWrite(GetCaptureFilePath());
-  EXPECT_THAT(capture_file_or_error, HasError("Incompatible version 0, expected 1"));
+  EXPECT_THAT(capture_file_or_error, HasErrorWithMessage("Incompatible version 0, expected 1"));
 }
 
 TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSize) {
@@ -350,7 +350,8 @@ TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSize) {
   EXPECT_THAT(orbit_base::WriteStringToFile(GetCaptureFilePath(), header), HasNoError());
 
   auto capture_file_or_error = CaptureFile::OpenForReadWrite(GetCaptureFilePath());
-  EXPECT_THAT(capture_file_or_error, HasError("Unexpected EOF while reading section list"));
+  EXPECT_THAT(capture_file_or_error,
+              HasErrorWithMessage("Unexpected EOF while reading section list"));
 }
 
 TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSizeTooLarge) {
@@ -363,7 +364,7 @@ TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSizeTooLarge) {
   EXPECT_THAT(orbit_base::WriteStringToFile(GetCaptureFilePath(), header), HasNoError());
 
   auto capture_file_or_error = CaptureFile::OpenForReadWrite(GetCaptureFilePath());
-  EXPECT_THAT(capture_file_or_error, HasError("The section list is too large"));
+  EXPECT_THAT(capture_file_or_error, HasErrorWithMessage("The section list is too large"));
 }
 
 TEST_F(CaptureFileTest, AddSectionOfTypeNoUserDataSection) {
@@ -410,8 +411,9 @@ TEST_F(CaptureFileTest, AddSectionOfTypeContainsUserDataSection) {
 }
 
 TEST_F(CaptureFileTest, CannotAddUserDataSectionAsAdditionalSection) {
-  EXPECT_THAT(capture_file_->AddAdditionalSectionOfType(kSectionTypeUserData, 50),
-              HasError("Cannot add a user data section as an additional (read only) section."));
+  EXPECT_THAT(
+      capture_file_->AddAdditionalSectionOfType(kSectionTypeUserData, 50),
+      HasErrorWithMessage("Cannot add a user data section as an additional (read only) section."));
 }
 
 TEST_F(CaptureFileHeaderTest, ModifyExisting) {

--- a/src/CaptureFileInfo/ManagerTest.cpp
+++ b/src/CaptureFileInfo/ManagerTest.cpp
@@ -26,7 +26,7 @@
 
 namespace orbit_capture_file_info {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 
 constexpr const char* kOrgName = "The Orbit Authors";
 
@@ -200,7 +200,7 @@ TEST(CaptureFileInfoManager, FillFromDirectory) {
 
   {  // Fail
     ErrorMessageOr<void> result = manager.FillFromDirectory("/non/existent/path/to/dir");
-    EXPECT_THAT(result, HasError("Unable to list files in directory"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to list files in directory"));
   }
 
   {  // Success

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -23,7 +23,7 @@
 using orbit_client_data::ModuleIdentifier;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 using testing::AllOf;
@@ -494,8 +494,8 @@ TEST(ProcessData, FindModuleByAddress) {
   {
     // exactly end address
     const auto result = process.FindModuleByAddress(end_address);
-    EXPECT_THAT(result, HasError("Unable to find module for address"));
-    EXPECT_THAT(result, HasError("No module loaded at this address"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to find module for address"));
+    EXPECT_THAT(result, HasErrorWithMessage("No module loaded at this address"));
   }
   {
     // after end address
@@ -572,7 +572,8 @@ TEST(ProcessData, RemapModule) {
   info.set_name(kProcessName);
   ProcessData process(info, &module_identifier_provider);
 
-  EXPECT_THAT(process.FindModuleByAddress(0), HasError("Unable to find module for address"));
+  EXPECT_THAT(process.FindModuleByAddress(0),
+              HasErrorWithMessage("Unable to find module for address"));
 
   ModuleInfo module_info;
   module_info.set_file_path(kModulePath);
@@ -721,9 +722,12 @@ TEST_F(ProcessDataModuleIntersectionTest, IntersectWithTwoModules) {
     EXPECT_EQ(result.value().end(), 250);
 
     // Intersecting modules are gone
-    EXPECT_THAT(process_.FindModuleByAddress(148), HasError("Unable to find module for address"));
-    EXPECT_THAT(process_.FindModuleByAddress(250), HasError("Unable to find module for address"));
-    EXPECT_THAT(process_.FindModuleByAddress(270), HasError("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(148),
+                HasErrorWithMessage("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(250),
+                HasErrorWithMessage("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(270),
+                HasErrorWithMessage("Unable to find module for address"));
   }
 }
 
@@ -822,8 +826,10 @@ TEST_F(ProcessDataModuleIntersectionTest, FullyInsideAnotherModuleAddressRange) 
     EXPECT_EQ(result.value().end(), 190);
 
     // Original module is gone
-    EXPECT_THAT(process_.FindModuleByAddress(108), HasError("Unable to find module for address"));
-    EXPECT_THAT(process_.FindModuleByAddress(190), HasError("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(108),
+                HasErrorWithMessage("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(190),
+                HasErrorWithMessage("Unable to find module for address"));
   }
 }
 
@@ -862,7 +868,8 @@ TEST_F(ProcessDataModuleIntersectionTest, ReplaceFirstModule) {
     EXPECT_EQ(result.value().end(), 90);
 
     // Original module is gone
-    EXPECT_THAT(process_.FindModuleByAddress(90), HasError("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(90),
+                HasErrorWithMessage("Unable to find module for address"));
   }
 
   // Non intersecting modules are still there
@@ -917,7 +924,8 @@ TEST_F(ProcessDataModuleIntersectionTest, ReplaceLastModule) {
     EXPECT_EQ(result.value().end(), 450);
 
     // Original module is gone
-    EXPECT_THAT(process_.FindModuleByAddress(310), HasError("Unable to find module for address"));
+    EXPECT_THAT(process_.FindModuleByAddress(310),
+                HasErrorWithMessage("Unable to find module for address"));
   }
 
   // Non intersecting modules are still there

--- a/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
@@ -37,7 +37,7 @@ namespace orbit_config_widgets {
 namespace {
 
 using orbit_client_symbols::ModuleSymbolFileMappings;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 class MockPersistentStorageManager : public orbit_client_symbols::PersistentStorageManager {
@@ -237,7 +237,8 @@ TEST_F(SymbolLocationsDialogTest, TryAddSymbolPath) {
   {  // add the same path again -> warning that needs to be dismissed and nothing changes
     auto result = dialog.TryAddSymbolPath(path);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result, HasError("Unable to add selected path, it is already part of the list."));
+    EXPECT_THAT(result, HasErrorWithMessage(
+                            "Unable to add selected path, it is already part of the list."));
     EXPECT_EQ(list_widget->count(), 1);
   }
 
@@ -274,7 +275,7 @@ TEST_F(SymbolLocationsDialogTest, TryAddSymbolFileWithoutModule) {
   std::filesystem::path text_file = orbit_test::GetTestdataDir() / "textfile.txt";
   {
     auto result = dialog.TryAddSymbolFile(text_file);
-    EXPECT_THAT(result, HasError("The selected file is not a viable symbol file"));
+    EXPECT_THAT(result, HasErrorWithMessage("The selected file is not a viable symbol file"));
   }
 
   // fails because no build-id
@@ -283,7 +284,7 @@ TEST_F(SymbolLocationsDialogTest, TryAddSymbolFileWithoutModule) {
   {
     auto result = dialog.TryAddSymbolFile(hello_world_elf_no_build_id);
 
-    EXPECT_THAT(result, HasError("The selected file does not contain a build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("The selected file does not contain a build id"));
   }
 }
 
@@ -315,7 +316,8 @@ TEST_F(SymbolLocationsDialogTest, TryAddSymbolFileWithModuleNoOverride) {
   std::filesystem::path libc_debug = orbit_test::GetTestdataDir() / "libc.debug";
   {
     auto result = dialog.TryAddSymbolFile(libc_debug);
-    EXPECT_THAT(result, HasError("The build ids of module and symbols file do not match."));
+    EXPECT_THAT(result,
+                HasErrorWithMessage("The build ids of module and symbols file do not match."));
   }
 }
 

--- a/src/Http/HttpDownloadManagerTest.cpp
+++ b/src/Http/HttpDownloadManagerTest.cpp
@@ -48,14 +48,14 @@ using orbit_base::GetNotCanceled;
 using orbit_base::IsCanceled;
 using orbit_base::IsNotFound;
 using orbit_base::StopSource;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using DownloadResult = ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<void>>>;
 
 namespace {
 
 void VerifyDownloadError(const DownloadResult& result, std::string_view expected_error) {
-  EXPECT_THAT(result, HasError(expected_error));
+  EXPECT_THAT(result, HasErrorWithMessage(expected_error));
 }
 
 void VerifyDownloadCanceled(const DownloadResult& result) {

--- a/src/LinuxCaptureService/ExtractSignalFromMinidumpTest.cpp
+++ b/src/LinuxCaptureService/ExtractSignalFromMinidumpTest.cpp
@@ -14,7 +14,7 @@
 
 namespace orbit_linux_capture_service {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 TEST(ExtractSignalFromMinidump, ExtractSignal4) {
@@ -28,19 +28,19 @@ TEST(ExtractSignalFromMinidump, ExtractSignal4) {
 TEST(ExtractSignalFromMinidump, BrokenCoreFile) {
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "broken.core.dmp";
   const auto signal_or_error = ExtractSignalFromMinidump(file_path);
-  EXPECT_THAT(signal_or_error, HasError("Unexpected end of data."));
+  EXPECT_THAT(signal_or_error, HasErrorWithMessage("Unexpected end of data."));
 }
 
 TEST(ExtractSignalFromMinidump, EmptyCoreFile) {
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "empty.core.dmp";
   const auto signal_or_error = ExtractSignalFromMinidump(file_path);
-  EXPECT_THAT(signal_or_error, HasError("No termination signal found in core file."));
+  EXPECT_THAT(signal_or_error, HasErrorWithMessage("No termination signal found in core file."));
 }
 
 TEST(ExtractSignalFromMinidump, CoreFileDoesntExist) {
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "doesnt_exist.core.dmp";
   const auto signal_or_error = ExtractSignalFromMinidump(file_path);
-  EXPECT_THAT(signal_or_error, HasError("No such file or directory"));
+  EXPECT_THAT(signal_or_error, HasErrorWithMessage("No such file or directory"));
 }
 
 }  // namespace orbit_linux_capture_service

--- a/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
@@ -28,8 +28,7 @@ using ::orbit_mizar_base::TID;
 using ::orbit_mizar_base::TimestampNs;
 using ::orbit_mizar_data::FrameTrackId;
 using ::orbit_mizar_data::FrameTrackInfo;
-using ::orbit_test_utils::HasError;
-using ::testing::_;
+using ::orbit_test_utils::HasErrorWithMessage;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -78,14 +77,14 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
           &bac,
           orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{TID(1)}, kStart, kId),
           orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{}, kStart, kId)),
-      HasError("Comparison: No threads selected"));
+      HasErrorWithMessage("Comparison: No threads selected"));
 
   EXPECT_THAT(
       validator.Validate(
           &bac, orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{}, kStart, kId),
           orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)}, kStart,
                                                        kId)),
-      HasError("Baseline: No threads selected"));
+      HasErrorWithMessage("Baseline: No threads selected"));
 
   constexpr RelativeTimeNs kOneNs(1);
 
@@ -95,7 +94,7 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
                       absl::flat_hash_set<TID>{TID(1)}, Add(kBaselineCaptureDuration, kOneNs), kId),
                   orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
                                                                kStart, kId)),
-              HasError("Baseline: Start > capture duration"));
+              HasErrorWithMessage("Baseline: Start > capture duration"));
 
   EXPECT_THAT(
       validator.Validate(
@@ -103,7 +102,7 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
           orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{TID(1)}, kStart, kId),
           orbit_mizar_base::MakeComparison<HalfConfig>(
               absl::flat_hash_set<TID>{TID(1)}, Add(kComparisonCaptureDuration, kOneNs), kId)),
-      HasError("Comparison: Start > capture duration"));
+      HasErrorWithMessage("Comparison: Start > capture duration"));
 }
 
 }  // namespace orbit_mizar_widgets

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -25,7 +25,7 @@
 #include "TestUtils/TestUtils.h"
 
 using orbit_grpc_protos::SymbolInfo;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 namespace orbit_object_utils {
@@ -179,7 +179,7 @@ TEST(CoffFile, LoadSymbolsFromExportTableNoExportTable) {
   EXPECT_FALSE(coff_file->HasExportTable());
 
   const auto symbols_result = coff_file->LoadSymbolsFromExportTable();
-  ASSERT_THAT(symbols_result, HasError("PE/COFF file does not have an Export Table"));
+  ASSERT_THAT(symbols_result, HasErrorWithMessage("PE/COFF file does not have an Export Table"));
 }
 
 TEST(CoffFile, LoadExceptionTableEntriesAsSymbolsNoChainedInfo) {
@@ -322,7 +322,8 @@ TEST(CoffFile, FailsWithErrorIfPdbDataNotPresent) {
   ASSERT_THAT(coff_file_or_error, HasNoError());
 
   auto pdb_debug_info_or_error = coff_file_or_error.value()->GetDebugPdbInfo();
-  ASSERT_THAT(pdb_debug_info_or_error, HasError("Object file does not have debug PDB info."));
+  ASSERT_THAT(pdb_debug_info_or_error,
+              HasErrorWithMessage("Object file does not have debug PDB info."));
 }
 
 TEST(CoffFile, GetsCorrectBuildIdIfPdbInfoIsPresent) {

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -27,7 +27,7 @@
 #include "TestUtils/TestUtils.h"
 
 using orbit_grpc_protos::SymbolInfo;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 namespace orbit_object_utils {
@@ -370,7 +370,7 @@ TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
 
   ASSERT_THAT(
       elf_file_result,
-      HasError(absl::StrFormat(
+      HasErrorWithMessage(absl::StrFormat(
           "Unable to get load bias of ELF file: \"%s\". No executable PT_LOAD segment found.",
           test_elf_file.string())));
 }
@@ -646,7 +646,7 @@ TEST(ElfFile, GetLocationOfFunctionNoSubroutine) {
 
   constexpr uint64_t kAddressOfFunction = 0x10a0e0;
   EXPECT_THAT(program.value()->GetDeclarationLocationOfFunction(kAddressOfFunction),
-              orbit_test_utils::HasError("Address not associated with any subroutine"));
+              orbit_test_utils::HasErrorWithMessage("Address not associated with any subroutine"));
 
   ErrorMessageOr<orbit_grpc_protos::LineInfo> function_location =
       program.value()->GetLocationOfFunction(kAddressOfFunction);

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -231,7 +231,7 @@ TYPED_TEST_P(PdbFileTest, CreatePdbFailsOnNonPdbFile) {
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
       TypeParam::CreatePdbFile(file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
-  EXPECT_THAT(pdb_file_result, orbit_test_utils::HasError("Unable to load PDB file"));
+  EXPECT_THAT(pdb_file_result, orbit_test_utils::HasErrorWithMessage("Unable to load PDB file"));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(PdbFileTest, LoadDebugSymbols, LoadsFunctionsOnlyInPublicSymbols,

--- a/src/ObjectUtils/SymbolsFileTest.cpp
+++ b/src/ObjectUtils/SymbolsFileTest.cpp
@@ -14,7 +14,7 @@
 
 namespace orbit_object_utils {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 TEST(SymbolsFile, CreateSymbolsFileFromElf) {
@@ -28,8 +28,8 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
       orbit_test::GetTestdataDir() / "no_symbols_elf";
 
   auto invalid_symbols_file = CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000});
-  EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
-  EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
+  EXPECT_THAT(invalid_symbols_file, HasErrorWithMessage("Unable to create symbols file"));
+  EXPECT_THAT(invalid_symbols_file, HasErrorWithMessage("File does not contain symbols."));
 }
 
 TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
@@ -42,8 +42,8 @@ TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
       orbit_test::GetTestdataDir() / "dllmain.dll";
 
   auto invalid_symbols_file = CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000});
-  EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
-  EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
+  EXPECT_THAT(invalid_symbols_file, HasErrorWithMessage("Unable to create symbols file"));
+  EXPECT_THAT(invalid_symbols_file, HasErrorWithMessage("File does not contain symbols."));
 }
 
 TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
@@ -59,14 +59,14 @@ TEST(SymbolsFile, FailToCreateSymbolsFile) {
   const std::filesystem::path path_to_text_file = orbit_test::GetTestdataDir() / "textfile.txt";
 
   auto text_file = CreateSymbolsFile(path_to_text_file, ObjectFileInfo{0x10000});
-  EXPECT_THAT(text_file, HasError("Unable to create symbols file"));
-  EXPECT_THAT(text_file, HasError("File cannot be read as an object file"));
-  EXPECT_THAT(text_file, HasError("File also cannot be read as a PDB file"));
+  EXPECT_THAT(text_file, HasErrorWithMessage("Unable to create symbols file"));
+  EXPECT_THAT(text_file, HasErrorWithMessage("File cannot be read as an object file"));
+  EXPECT_THAT(text_file, HasErrorWithMessage("File also cannot be read as a PDB file"));
 
   const std::filesystem::path invalid_path = orbit_test::GetTestdataDir() / "non_existing_file";
   auto invalid_file = CreateSymbolsFile(invalid_path, ObjectFileInfo{0x10000});
-  EXPECT_THAT(invalid_file, HasError("Unable to create symbols file"));
-  EXPECT_THAT(invalid_file, HasError("File does not exist"));
+  EXPECT_THAT(invalid_file, HasErrorWithMessage("Unable to create symbols file"));
+  EXPECT_THAT(invalid_file, HasErrorWithMessage("File does not exist"));
 }
 
 }  // namespace orbit_object_utils

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -27,6 +27,7 @@
 #include "TestUtils/TestUtils.h"
 
 using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 using orbit_test_utils::TemporaryFile;
@@ -408,7 +409,7 @@ TEST(File, FileSize) {
     ErrorMessageOr<uint64_t> file_size_or_error = FileSize(file_path);
     // On Windows the error message is: "The system cannot find the file specified."
     // On Linux it is: "No such file or directory"
-    EXPECT_THAT(file_size_or_error, HasError("file"));
+    EXPECT_THAT(file_size_or_error, HasErrorWithMessage("file"));
   }
 }
 
@@ -460,9 +461,9 @@ TEST(File, IsDirectory) {
     // On Windows the error message is: " The system cannot find the path specified."
     // On Linux it is: "No such file or directory"
     EXPECT_THAT(IsDirectory(std::filesystem::path{"/tmp/complicated/non/existing/path/to/file"}),
-                HasError(""));
+                HasError());
     EXPECT_THAT(IsDirectory(std::filesystem::path{"/tmp/complicated/non/existing/path/to/folder/"}),
-                HasError(""));
+                HasError());
   }
 }
 

--- a/src/OrbitBase/GetProcAddressTest.cpp
+++ b/src/OrbitBase/GetProcAddressTest.cpp
@@ -12,7 +12,7 @@
 
 namespace orbit_base {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 
 TEST(GetProcAddress, FindExistingFunctions) {
   static auto set_thread_description =
@@ -25,12 +25,12 @@ TEST(GetProcAddress, FindExistingFunctions) {
 
 TEST(GetProcAddress, NonExistingModule) {
   EXPECT_THAT(GetProcAddress("non_existing.dll", "non_existing_function_name"),
-              HasError("Could not find module"));
+              HasErrorWithMessage("Could not find module"));
 }
 
 TEST(GetProcAddress, NonExistingFunction) {
   EXPECT_THAT(GetProcAddress("kernel32.dll", "non_existing_function_name"),
-              HasError("Could not find function"));
+              HasErrorWithMessage("Could not find function"));
 }
 
 }  // namespace orbit_base

--- a/src/OrbitSsh/CredentialsTest.cpp
+++ b/src/OrbitSsh/CredentialsTest.cpp
@@ -18,7 +18,7 @@
 #include "TestUtils/TestUtils.h"
 
 namespace orbit_ssh {
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 using testing::Field;
 using testing::UnorderedElementsAre;
@@ -73,7 +73,7 @@ TEST(FindUsersCredentials, FailsWhenKnownHostsMissing) {
       orbit_test::GetTestdataDir() / "missing_known_hosts_ssh_config";
   auto result = FindUsersCredentials(ssh_config_dir, addr_and_port, username);
 
-  EXPECT_THAT(result, HasError("No known_hosts file found"));
+  EXPECT_THAT(result, HasErrorWithMessage("No known_hosts file found"));
 }
 
 TEST(FindUsersCredentials, FailsWhenNoKeyFound) {
@@ -84,7 +84,7 @@ TEST(FindUsersCredentials, FailsWhenNoKeyFound) {
       orbit_test::GetTestdataDir() / "missing_key_ssh_config";
   auto result = FindUsersCredentials(ssh_config_dir, addr_and_port, username);
 
-  EXPECT_THAT(result, HasError("No valid and/or supported SSH key files found"));
+  EXPECT_THAT(result, HasErrorWithMessage("No valid and/or supported SSH key files found"));
 }
 
 }  // namespace orbit_ssh

--- a/src/OrbitSshQt/TunnelTest.cpp
+++ b/src/OrbitSshQt/TunnelTest.cpp
@@ -35,7 +35,7 @@ Q_DECLARE_METATYPE(std::error_code);
 namespace orbit_ssh_qt {
 using orbit_qt_test_utils::WaitFor;
 using orbit_qt_test_utils::YieldsResult;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 // This test fixure inherits all the functionality from SshTestFixture and on top ensures that
@@ -104,7 +104,7 @@ TEST_F(SshTunnelTest, StartFails) {
   qRegisterMetaType<std::error_code>("std::error_code");
   QSignalSpy error_signal{&tunnel, &orbit_ssh_qt::Tunnel::errorOccurred};
 
-  EXPECT_THAT(WaitFor(tunnel.Start()), YieldsResult(HasError("Channel failure")));
+  EXPECT_THAT(WaitFor(tunnel.Start()), YieldsResult(HasErrorWithMessage("Channel failure")));
   EXPECT_THAT(error_signal, testing::SizeIs(1));
 }
 

--- a/src/ProcessService/ProcessServiceUtilsTest.cpp
+++ b/src/ProcessService/ProcessServiceUtilsTest.cpp
@@ -23,7 +23,7 @@ namespace orbit_process_service {
 
 using orbit_base::NotFoundOr;
 using orbit_grpc_protos::GetDebugInfoFileRequest;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 TEST(ProcessServiceUtils, GetCumulativeTotalCpuTime) {
@@ -120,7 +120,7 @@ TEST(ProcessServiceUtils, FindSymbolsFilePath) {
     request.set_module_path(module_path.string());
     request.add_additional_search_directories(test_directory);
     const ErrorMessageOr<NotFoundOr<std::filesystem::path>> result = FindSymbolsFilePath(request);
-    EXPECT_THAT(result, HasError("Unable to load object file"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to load object file"));
   }
 
   {  // elf - no build id, but does include symbols

--- a/src/QtUtils/EventLoopTest.cpp
+++ b/src/QtUtils/EventLoopTest.cpp
@@ -14,6 +14,8 @@
 #include "QtUtils/EventLoop.h"
 #include "TestUtils/TestUtils.h"
 
+using orbit_test_utils::HasErrorWithMessage;
+
 TEST(EventLoop, exec) {
   // Case 1: The event loop finishes successfully
   {
@@ -43,9 +45,9 @@ TEST(EventLoop, exec) {
           loop.error(std::make_error_code(std::errc::bad_message));
         },
         Qt::QueuedConnection);
-    EXPECT_THAT(loop.exec(),
-                orbit_test_utils::HasError(
-                    ErrorMessage{std::make_error_code(std::errc::bad_message)}.message()));
+    EXPECT_THAT(
+        loop.exec(),
+        HasErrorWithMessage(ErrorMessage{std::make_error_code(std::errc::bad_message)}.message()));
   }
 
   // Case 3: The event loop immediately returns due to a queued error.
@@ -61,9 +63,9 @@ TEST(EventLoop, exec) {
                    // to return early.
         },
         Qt::QueuedConnection);
-    EXPECT_THAT(loop.exec(),
-                orbit_test_utils::HasError(
-                    ErrorMessage{std::make_error_code(std::errc::bad_message)}.message()));
+    EXPECT_THAT(
+        loop.exec(),
+        HasErrorWithMessage(ErrorMessage{std::make_error_code(std::errc::bad_message)}.message()));
   }
 
   // Case 4: The event loop immediately returns due to a queued result (quit).
@@ -138,7 +140,7 @@ TEST(EventLoop, reuseLoop) {
           loop.error(error_code);
         },
         Qt::QueuedConnection);
-    EXPECT_THAT(loop.exec(), orbit_test_utils::HasError(ErrorMessage{error_code}.message()));
+    EXPECT_THAT(loop.exec(), HasErrorWithMessage(ErrorMessage{error_code}.message()));
   }
 
   // 3. normal error from ErrorMessage
@@ -152,7 +154,7 @@ TEST(EventLoop, reuseLoop) {
         },
         Qt::QueuedConnection);
 
-    EXPECT_THAT(loop.exec(), orbit_test_utils::HasError(error_message.message()));
+    EXPECT_THAT(loop.exec(), HasErrorWithMessage(error_message.message()));
   }
 
   // 4. premature quit
@@ -173,13 +175,13 @@ TEST(EventLoop, reuseLoop) {
   {
     const auto error_code = std::make_error_code(std::errc::bad_message);
     loop.error(error_code);
-    EXPECT_THAT(loop.exec(), orbit_test_utils::HasError(ErrorMessage{error_code}.message()));
+    EXPECT_THAT(loop.exec(), HasErrorWithMessage(ErrorMessage{error_code}.message()));
   }
 
   // 6. premature error from ErrorMessage
   {
     const ErrorMessage error_message{"Important error message"};
     loop.error(error_message);
-    EXPECT_THAT(loop.exec(), orbit_test_utils::HasError(error_message.message()));
+    EXPECT_THAT(loop.exec(), HasErrorWithMessage(error_message.message()));
   }
 }

--- a/src/QtUtils/ExecuteProcessTest.cpp
+++ b/src/QtUtils/ExecuteProcessTest.cpp
@@ -29,7 +29,7 @@
 namespace orbit_qt_utils {
 
 using orbit_base::Future;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 TEST(QtUtilsExecuteProcess, ProgramNotFound) {
@@ -43,9 +43,9 @@ TEST(QtUtilsExecuteProcess, ProgramNotFound) {
   future.Then(&mte, [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
-    EXPECT_THAT(result, HasError("Error occurred while executing process"));
-    EXPECT_THAT(result, HasError("non_existing_process"));
-    EXPECT_THAT(result, HasError("FailedToStart"));
+    EXPECT_THAT(result, HasErrorWithMessage("Error occurred while executing process"));
+    EXPECT_THAT(result, HasErrorWithMessage("non_existing_process"));
+    EXPECT_THAT(result, HasErrorWithMessage("FailedToStart"));
     QCoreApplication::exit();
   });
 
@@ -68,7 +68,7 @@ TEST(QtUtilsExecuteProcess, ReturnsFailExitCode) {
   future.Then(&mte, [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
-    EXPECT_THAT(result, HasError("failed with exit code: 240"));
+    EXPECT_THAT(result, HasErrorWithMessage("failed with exit code: 240"));
     QCoreApplication::exit();
   });
 
@@ -165,7 +165,7 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeout) {
   future.Then(&mte, [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
-    EXPECT_THAT(result, HasError("timed out after 100ms"));
+    EXPECT_THAT(result, HasErrorWithMessage("timed out after 100ms"));
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
@@ -192,7 +192,7 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeoutWithValueZero) {
   future.Then(&mte, [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
-    EXPECT_THAT(result, HasError("timed out after 0ms"));
+    EXPECT_THAT(result, HasErrorWithMessage("timed out after 0ms"));
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
@@ -221,7 +221,7 @@ TEST(QtUtilsExecuteProcess, ParentGetsDeletedImmediately) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
 
-    EXPECT_THAT(result, HasError("killed because the parent object was destroyed"));
+    EXPECT_THAT(result, HasErrorWithMessage("killed because the parent object was destroyed"));
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
@@ -251,7 +251,7 @@ TEST(QtUtilsExecuteProcess, ParentGetsDeletedWhileExecuting) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
 
-    EXPECT_THAT(result, HasError("killed because the parent object was destroyed"));
+    EXPECT_THAT(result, HasErrorWithMessage("killed because the parent object was destroyed"));
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
@@ -284,7 +284,7 @@ TEST(QtUtilsExecuteProcess, ProcessFinishAndTimeoutRace) {
     lambda_was_called = true;
 
     if (result.has_error()) {
-      EXPECT_THAT(result, HasError("timed out after 100ms"));
+      EXPECT_THAT(result, HasErrorWithMessage("timed out after 100ms"));
     } else {
       ASSERT_THAT(result, HasValue());
       EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
@@ -321,7 +321,7 @@ TEST(QtUtilsExecuteProcess, ProcessFinishAndParentGetsDeletedRace) {
     lambda_was_called = true;
 
     if (result.has_error()) {
-      EXPECT_THAT(result, HasError("killed because the parent object was destroyed"));
+      EXPECT_THAT(result, HasErrorWithMessage("killed because the parent object was destroyed"));
     } else {
       ASSERT_THAT(result, HasValue());
       EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -35,7 +35,7 @@ using orbit_base::Future;
 using orbit_base::NotFoundOr;
 using orbit_symbol_provider::SymbolLoadingOutcome;
 using orbit_symbol_provider::SymbolLoadingSuccessResult;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using ::testing::_;
 using ::testing::Return;
@@ -165,7 +165,7 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleError) {
       .RetrieveSymbols({.module_path = kValidModulePath, .build_id = kValidModuleBuildId},
                        stop_source.GetStopToken())
       .Then(&executor_, [error_msg](const SymbolLoadingOutcome& result) {
-        EXPECT_THAT(result, HasError(error_msg));
+        EXPECT_THAT(result, HasErrorWithMessage(error_msg));
 
         QCoreApplication::exit();
       });

--- a/src/SessionSetup/OtherUserDialogTest.cpp
+++ b/src/SessionSetup/OtherUserDialogTest.cpp
@@ -22,7 +22,7 @@ constexpr const char* kRememberKey = "OtherUserDialog.RememberKey";
 
 namespace orbit_session_setup {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 TEST(OtherUserDialog, ExecAccept) {
@@ -51,7 +51,7 @@ TEST(OtherUserDialog, ExecReject) {
       &dialog, [&]() { dialog.reject(); }, Qt::QueuedConnection);
 
   auto result = dialog.Exec();
-  EXPECT_THAT(result, HasError("user rejected"));
+  EXPECT_THAT(result, HasErrorWithMessage("user rejected"));
 }
 
 TEST(OtherUserDialog, Remember) {

--- a/src/SymbolProvider/StructuredDebugDirectorySymbolProviderTest.cpp
+++ b/src/SymbolProvider/StructuredDebugDirectorySymbolProviderTest.cpp
@@ -98,7 +98,7 @@ TEST_F(StructuredDebugDirectorySymbolProviderTest, RetrieveSymbolsError) {
     future
         .Then(&executor,
               [&](const SymbolLoadingOutcome& result) {
-                ASSERT_THAT(result, orbit_test_utils::HasError("malformed"));
+                ASSERT_THAT(result, orbit_test_utils::HasErrorWithMessage("malformed"));
                 lambda_executed = true;
               })
         .Wait();

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -28,7 +28,7 @@ using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_object_utils::ObjectFileInfo;
 using orbit_symbols::SymbolHelper;
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 
@@ -162,68 +162,68 @@ TEST(SymbolHelper, FindSymbolsFileLocally) {
     const fs::path non_existing_path = "file.not.exist";
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         non_existing_path, "irrelevant build id", ModuleInfo::kElfFile, {testdata_directory});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Directly provided symbols file does not exist
     const fs::path symbols_path = testdata_directory / "file.not.exist";
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         "irrelevant module path", "irrelevant build id", ModuleInfo::kElfFile, {symbols_path});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Find .debug fails because of wrong build id - in directory
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         no_symbols_elf, "wrong build id", ModuleInfo::kElfFile, {testdata_directory});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Find .debug fails because of wrong build id - directly
 
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         no_symbols_elf, "wrong build id", ModuleInfo::kElfFile, {no_symbols_elf_debug});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Find .pdb fails because of wrong build id - in directory
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         dllmain_dll, "wrong build id", ModuleInfo::kCoffFile, {testdata_directory});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Find .pdb fails because of wrong build id - directly
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         dllmain_dll, "wrong build id", ModuleInfo::kCoffFile, {dllmain_pdb});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
   }
 
   {  // Find .debug fails because of module does not have build id
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         no_symbols_elf, "", ModuleInfo::kElfFile, {testdata_directory});
-    EXPECT_THAT(symbols_path_result, HasError("Could not find"));
-    EXPECT_THAT(symbols_path_result, HasError("does not contain a build id"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("Could not find"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("does not contain a build id"));
   }
 
   {  // Find .pdb fails because of module does not have build id
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         dllmain_dll, "", ModuleInfo::kCoffFile, {testdata_directory});
-    EXPECT_THAT(symbols_path_result, HasError("does not contain a build id"));
+    EXPECT_THAT(symbols_path_result, HasErrorWithMessage("does not contain a build id"));
   }
 
   {  // Find .debug fails because of object_file_type is wrong
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         no_symbols_elf, no_symbols_elf_build_id, ModuleInfo::kCoffFile, {testdata_directory});
-    EXPECT_THAT(
-        symbols_path_result,
-        HasError("Could not find a file with debug symbols on the local machine for module"));
+    EXPECT_THAT(symbols_path_result,
+                HasErrorWithMessage(
+                    "Could not find a file with debug symbols on the local machine for module"));
   }
 
   {  // Find .pdb fails because of object_file_type is wrong
     const auto symbols_path_result = symbol_helper.FindSymbolsFileLocally(
         dllmain_dll, dllmain_build_id, ModuleInfo::kElfFile, {testdata_directory});
-    EXPECT_THAT(
-        symbols_path_result,
-        HasError("Could not find a file with debug symbols on the local machine for module"));
+    EXPECT_THAT(symbols_path_result,
+                HasErrorWithMessage(
+                    "Could not find a file with debug symbols on the local machine for module"));
   }
 }
 
@@ -246,8 +246,8 @@ TEST(SymbolHelper, FindSymbolsInCacheBySize) {
     const auto file_size = orbit_base::FileSize(testdata_directory / file_name);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindSymbolsInCache(file_name, file_size.value());
-    EXPECT_THAT(result, HasError("Unable to load symbols file"));
-    EXPECT_THAT(result, HasError("File does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to load symbols file"));
+    EXPECT_THAT(result, HasErrorWithMessage("File does not contain symbols"));
   }
   {
     // File in cache has different size.
@@ -255,13 +255,13 @@ TEST(SymbolHelper, FindSymbolsInCacheBySize) {
     const auto file_size = orbit_base::FileSize(testdata_directory / file_name);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindSymbolsInCache(file_name, file_size.value() + 1);
-    EXPECT_THAT(result, HasError("File size doesn't match"));
+    EXPECT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
   {
     // File doesn't exist.
     const fs::path file_name = "non-existing_file";
     const auto result = symbol_helper.FindSymbolsInCache(file_name, 42);
-    EXPECT_THAT(result, HasError("Unable to find symbols in cache"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to find symbols in cache"));
   }
 }
 
@@ -289,32 +289,32 @@ TEST(SymbolHelper, FindSymbolsInCache) {
     const fs::path file_name = "no_symbols_elf";
     const auto result =
         symbol_helper.FindSymbolsInCache(file_name, "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b");
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // COFF file in cache does not have symbols.
     const fs::path file_name = "dllmain.dll";
     const auto result =
         symbol_helper.FindSymbolsInCache(file_name, "92cdaeef73f74ebbbcf213b84f43b322-3");
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // ELF file in cache has different build id.
     const fs::path file_name = "no_symbols_elf.debug";
     const auto result = symbol_helper.FindSymbolsInCache(file_name, "non matching build id");
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // PDB in cache has different build id.
     const fs::path file_name = "dllmain.pdb";
     const auto result = symbol_helper.FindSymbolsInCache(file_name, "non matching build id");
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // File doesn't exist.
     const fs::path file_name = "non-existing_file";
     const auto result = symbol_helper.FindSymbolsInCache(file_name, "unimportant build id");
-    EXPECT_THAT(result, HasError("Unable to find symbols in cache"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to find symbols in cache"));
   }
 }
 
@@ -340,7 +340,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     ASSERT_THAT(file_size, HasNoError());
     const auto result =
         symbol_helper.FindObjectInCache(file_name, "non-matching build id", file_size.value());
-    ASSERT_THAT(result, HasError("has a different build id"));
+    ASSERT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // ELF file has a different size.
@@ -350,7 +350,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
         file_name, "d12d54bc5b72ccce54a408bdeda65e2530740ac8", file_size.value() + 1);
-    ASSERT_THAT(result, HasError("File size doesn't match"));
+    ASSERT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
   {
     // COFF file.
@@ -371,7 +371,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     ASSERT_THAT(file_size, HasNoError());
     const auto result =
         symbol_helper.FindObjectInCache(file_name, "non-matching build id", file_size.value());
-    ASSERT_THAT(result, HasError("has a different build id"));
+    ASSERT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // COFF file has a different size.
@@ -381,7 +381,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
         file_name, "92cdaeef73f74ebbbcf213b84f43b322-3", file_size.value() + 1);
-    ASSERT_THAT(result, HasError("File size doesn't match"));
+    ASSERT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
   {
     // PDB file.
@@ -391,16 +391,16 @@ TEST(SymbolHelper, FindObjectInCache) {
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
         file_name, "92cdaeef73f74ebbbcf213b84f43b322-3", file_size.value());
-    EXPECT_THAT(result, HasError("The file was not recognized as a valid object file"));
+    EXPECT_THAT(result, HasErrorWithMessage("The file was not recognized as a valid object file"));
   }
   {
     // File doesn't exist.
     const fs::path file_name = "non-existing_file";
     const fs::path file_path = testdata_directory / file_name;
     const auto file_size = orbit_base::FileSize(file_path);
-    ASSERT_THAT(file_size, HasError(""));
+    ASSERT_THAT(file_size, HasErrorWithMessage(""));
     const auto result = symbol_helper.FindObjectInCache(file_name, "unimportant build id", 42);
-    EXPECT_THAT(result, HasError("Unable to find object file in cache"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to find object file in cache"));
   }
 }
 
@@ -430,20 +430,20 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
     // ELF file does not contain symbols.
     const fs::path file_path = testdata_directory / "no_symbols_elf";
     const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // COFF file does not contain symbols.
     const fs::path file_path = testdata_directory / "dllmain.dll";
     const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // File doesn't exist.
     const fs::path file_path = testdata_directory / "file_does_not_exist";
     const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
-    EXPECT_THAT(result, HasError("Unable to create symbols file"));
-    EXPECT_THAT(result, HasError("File does not exist"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to create symbols file"));
+    EXPECT_THAT(result, HasErrorWithMessage("File does not exist"));
   }
 }
 
@@ -474,14 +474,14 @@ TEST(SymbolHelper, LoadFallbackSymbolsFromFile) {
     // PDB file.
     const fs::path file_path = testdata_directory / "dllmain.pdb";
     const auto module_symbols_or_error = SymbolHelper::LoadFallbackSymbolsFromFile(file_path);
-    EXPECT_THAT(module_symbols_or_error, HasError("Unable to load object file"));
+    EXPECT_THAT(module_symbols_or_error, HasErrorWithMessage("Unable to load object file"));
   }
   {
     // Files doesn't exist.
     const fs::path file_path = testdata_directory / "file_does_not_exist";
     const auto result = SymbolHelper::LoadFallbackSymbolsFromFile(file_path);
-    EXPECT_THAT(result, HasError("Unable to load object file"));
-    EXPECT_THAT(result, HasError("such file or directory"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to load object file"));
+    EXPECT_THAT(result, HasErrorWithMessage("such file or directory"));
   }
 }
 
@@ -537,7 +537,7 @@ TEST(FileStartsWithDeprecationNote, FileDoesNotExist) {
   ErrorMessageOr<bool> error_result =
       orbit_symbols::FileStartsWithDeprecationNote("non/existing/path/");
 
-  EXPECT_THAT(error_result, HasError("Unable to open file"));
+  EXPECT_THAT(error_result, HasErrorWithMessage("Unable to open file"));
 }
 
 TEST(FileStartsWithDeprecationNote, EmptyFile) {
@@ -591,7 +591,7 @@ TEST(FileStartsWithDeprecationNote, HasDeprecationNote) {
 TEST(AddDeprecationNoteToFile, FileDoesNotExist) {
   ErrorMessageOr<void> error_result = orbit_symbols::AddDeprecationNoteToFile("non/existing/path/");
 
-  EXPECT_THAT(error_result, HasError("Unable to open file"));
+  EXPECT_THAT(error_result, HasErrorWithMessage("Unable to open file"));
 }
 
 TEST(AddDeprecationNoteToFile, AddNote) {

--- a/src/Symbols/SymbolUtilsTest.cpp
+++ b/src/Symbols/SymbolUtilsTest.cpp
@@ -18,7 +18,7 @@
 
 namespace orbit_symbols {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 
@@ -78,14 +78,14 @@ TEST(SymbolUtils, VerifySymbolFileByBuildId) {
     const std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
     const std::string build_id = "incorrect build id";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // ELF file with matching build-id, but no symbols.
     const std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf";
     const std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // PDB file with symbols and matching build id.
@@ -99,21 +99,21 @@ TEST(SymbolUtils, VerifySymbolFileByBuildId) {
     const std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
     const std::string build_id = "incorrect build id";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // COFF file with matching build id, but no symbols.
     const std::filesystem::path symbols_file = testdata_directory / "dllmain.dll";
     const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
   }
   {
     // File doesn't exist.
     const std::filesystem::path symbols_file = "path/to/invalid_file";
     const std::string build_id = "build id does not matter";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("Unable to create symbols file"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to create symbols file"));
   }
 }
 
@@ -133,8 +133,8 @@ TEST(SymbolUtils, VerifySymbolFileBySize) {
     const auto file_size = orbit_base::FileSize(symbols_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifySymbolFile(symbols_file, file_size.value());
-    EXPECT_THAT(result, HasError("Unable to load symbols file"));
-    EXPECT_THAT(result, HasError("File does not contain symbols"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to load symbols file"));
+    EXPECT_THAT(result, HasErrorWithMessage("File does not contain symbols"));
   }
   {
     // File with symbols, but of mis-matching file size.
@@ -142,7 +142,7 @@ TEST(SymbolUtils, VerifySymbolFileBySize) {
     const auto file_size = orbit_base::FileSize(symbols_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifySymbolFile(symbols_file, file_size.value() + 1);
-    EXPECT_THAT(result, HasError("File size doesn't match"));
+    EXPECT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
 }
 
@@ -164,7 +164,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value());
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // ELF file with mis-matching size.
@@ -173,7 +173,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value() + 1);
-    EXPECT_THAT(result, HasError("File size doesn't match"));
+    EXPECT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
   {
     // COFF file with matching build id.
@@ -191,7 +191,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value());
-    EXPECT_THAT(result, HasError("has a different build id"));
+    EXPECT_THAT(result, HasErrorWithMessage("has a different build id"));
   }
   {
     // COFF file with mis-matching size.
@@ -200,7 +200,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value() + 1);
-    EXPECT_THAT(result, HasError("File size doesn't match"));
+    EXPECT_THAT(result, HasErrorWithMessage("File size doesn't match"));
   }
   {
     // PDB file.
@@ -209,14 +209,14 @@ TEST(SymbolUtils, VerifyObjectFile) {
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value());
-    EXPECT_THAT(result, HasError("The file was not recognized as a valid object file"));
+    EXPECT_THAT(result, HasErrorWithMessage("The file was not recognized as a valid object file"));
   }
   {
     // File doesn't exist.
     const std::filesystem::path object_file = "path/to/nothing";
     const std::string build_id = "build id does not matter";
     const auto result = VerifyObjectFile(object_file, build_id, 42);
-    EXPECT_THAT(result, HasError("Unable to load object file"));
+    EXPECT_THAT(result, HasErrorWithMessage("Unable to load object file"));
   }
 }
 

--- a/src/TestUtils/TestUtilsTest.cpp
+++ b/src/TestUtils/TestUtilsTest.cpp
@@ -15,6 +15,7 @@ static ErrorMessageOr<std::string> ReturnString() { return "This is fine."; }
 static ErrorMessageOr<std::string> ReturnError() { return ErrorMessage{"This is not fine."}; }
 
 namespace orbit_test_utils {
+using testing::_;
 
 TEST(TestUtils, HasValue) {
   EXPECT_THAT(ReturnString(), HasValue());
@@ -26,20 +27,30 @@ TEST(TestUtils, HasValue) {
   EXPECT_THAT(ReturnError(), testing::Not(HasValue(testing::Eq("This is fine."))));
 }
 
-TEST(TestUtils, HasError) {
-  EXPECT_THAT(ReturnString(), testing::Not(HasError("This is not fine")));
+TEST(TestUtils, HasErrorWithMessage) {
+  EXPECT_THAT(ReturnString(), testing::Not(HasErrorWithMessage("This is not fine")));
   EXPECT_THAT(ReturnString(), HasValue("This is fine."));
   EXPECT_THAT(ReturnString(), HasValue(testing::Eq("This is fine.")));
   EXPECT_THAT(ReturnString(), HasValue(testing::EndsWith("fine.")));
 
-  EXPECT_THAT(ReturnError(), HasError("This is not fine."));
-  EXPECT_THAT(ReturnError(), HasError("not fine."));
-  EXPECT_THAT(ReturnError(), testing::Not(HasError("Other error message")));
+  EXPECT_THAT(ReturnError(), HasErrorWithMessage("This is not fine."));
+  EXPECT_THAT(ReturnError(), HasErrorWithMessage("not fine."));
+  EXPECT_THAT(ReturnError(), testing::Not(HasErrorWithMessage("Other error message")));
 }
 
 TEST(TestUtils, HasNoError) {
   EXPECT_THAT(ReturnString(), HasNoError());
   EXPECT_THAT(ReturnError(), testing::Not(HasNoError()));
+}
+
+TEST(TestUtils, HasError) {
+  EXPECT_THAT(ReturnString(), testing::Not(HasError()));
+  EXPECT_THAT(ReturnString(), testing::Not(HasError(_)));
+
+  EXPECT_THAT(ReturnError(), HasError());
+  EXPECT_THAT(ReturnError(), HasError(_));
+  EXPECT_THAT(ReturnError(),
+              HasError(testing::Property(&ErrorMessage::message, "This is not fine.")));
 }
 
 }  // namespace orbit_test_utils

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -32,7 +32,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 
 AddressRange AddressRangeFromString(std::string_view string_address) {
   AddressRange result{};
@@ -108,18 +108,18 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
 
   // Process does not exist.
   result = ReadTraceesMemory(-1, address, length);
-  EXPECT_THAT(result, HasError("Unable to open file"));
+  EXPECT_THAT(result, HasErrorWithMessage("Unable to open file"));
 
   // Read 0 bytes.
   EXPECT_DEATH(auto unused_result = ReadTraceesMemory(pid, address, 0), "Check failed");
 
   // Read past the end of the mappings.
   result = ReadTraceesMemory(pid, continuous_range.end - length, length + 1);
-  EXPECT_THAT(result, HasError("Input/output error"));
+  EXPECT_THAT(result, HasErrorWithMessage("Input/output error"));
 
   // Read from bad address.
   result = ReadTraceesMemory(pid, 0, length);
-  EXPECT_THAT(result, HasError("Input/output error"));
+  EXPECT_THAT(result, HasErrorWithMessage("Input/output error"));
 
   // Detach and end child.
   ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
@@ -167,7 +167,7 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
 
   // Process does not exist.
   result = WriteTraceesMemory(-1, address, bytes);
-  EXPECT_THAT(result, HasError("Unable to open file"));
+  EXPECT_THAT(result, HasErrorWithMessage("Unable to open file"));
 
   // Write 0 bytes.
   EXPECT_DEATH(auto unused_result = WriteTraceesMemory(pid, address, std::vector<uint8_t>()),
@@ -176,11 +176,11 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   // Write past the end of the mappings.
   bytes.push_back(0);
   result = WriteTraceesMemory(pid, continuous_range.end - length, bytes);
-  EXPECT_THAT(result, HasError("Input/output error"));
+  EXPECT_THAT(result, HasErrorWithMessage("Input/output error"));
 
   // Write to bad address.
   result = WriteTraceesMemory(pid, 0, bytes);
-  EXPECT_THAT(result, HasError("Input/output error"));
+  EXPECT_THAT(result, HasErrorWithMessage("Input/output error"));
 
   // Restore, detach and end child.
   ORBIT_CHECK(!WriteTraceesMemory(pid, address, backup.value()).has_error());

--- a/src/UserSpaceInstrumentation/AttachTest.cpp
+++ b/src/UserSpaceInstrumentation/AttachTest.cpp
@@ -19,13 +19,13 @@
 
 namespace orbit_user_space_instrumentation {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 
 TEST(AttachTest, AttachAndStopProcess) {
   TestProcess test_process;
   const pid_t pid = test_process.pid();
 
-  EXPECT_THAT(AttachAndStopProcess(-1), HasError("There is no process with pid"));
+  EXPECT_THAT(AttachAndStopProcess(-1), HasErrorWithMessage("There is no process with pid"));
 
   const auto result = AttachAndStopProcess(pid);
   ASSERT_FALSE(result.has_error()) << result.error().message();

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -42,7 +42,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using testing::Eq;
 
@@ -219,7 +219,7 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   const std::string non_existing_lib_name = "libNotFound.so";
   auto library_handle_or_error = DlmopenInTracee(pid, modules, non_existing_lib_name, RTLD_NOW,
                                                  LinkerNamespace::kCreateNewNamespace);
-  ASSERT_THAT(library_handle_or_error, HasError("Library does not exist at"));
+  ASSERT_THAT(library_handle_or_error, HasErrorWithMessage("Library does not exist at"));
 
   // Continue child process.
   ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -39,7 +39,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 using ::testing::HasSubstr;
 
@@ -130,7 +130,7 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(pid);
   auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(result_or_error, HasError("is already being traced by"));
+  ASSERT_THAT(result_or_error, HasErrorWithMessage("is already being traced by"));
 
   // End tracer process, end child process.
   kill(pid_tracer, SIGKILL);
@@ -145,7 +145,7 @@ TEST(InstrumentProcessTest, FailToInstrumentInvalidPid) {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(-1);
   auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(result_or_error, HasError("There is no process with pid"));
+  ASSERT_THAT(result_or_error, HasErrorWithMessage("There is no process with pid"));
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
@@ -154,7 +154,7 @@ TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(getpid());
   auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(result_or_error, HasError("The target process is OrbitService itself."));
+  ASSERT_THAT(result_or_error, HasErrorWithMessage("The target process is OrbitService itself."));
 }
 
 static void VerifyTrampolineAddressRangesAndLibraryPath(
@@ -375,8 +375,9 @@ TEST(InstrumentProcessTest, AnyTargetThreadInStrictSeccompMode) {
   orbit_grpc_protos::CaptureOptions capture_options = BuildCaptureOptions();
   capture_options.set_pid(pid);
   auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(result_or_error,
-              HasError("At least one thread of the target process is in strict seccomp mode."));
+  ASSERT_THAT(
+      result_or_error,
+      HasErrorWithMessage("At least one thread of the target process is in strict seccomp mode."));
 
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -23,7 +23,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 
 // Let the parent trace us, write into rax and ymm0, then enter a breakpoint. While the child is
 // stopped the parent modifies the registers and continues the child. The child then reads back the
@@ -110,8 +110,10 @@ TEST(RegisterStateTest, BackupModifyRestore) {
   EXPECT_EQ(WEXITSTATUS(status), 0);
 
   // After the process exited we get errors when backing up / restoring registers.
-  EXPECT_THAT(state.RestoreRegisters(), HasError("PTRACE_SETREGSET failed to write NT_PRSTATUS"));
-  EXPECT_THAT(state.BackupRegisters(pid), HasError("PTRACE_GETREGS, NT_PRSTATUS failed"));
+  EXPECT_THAT(state.RestoreRegisters(),
+              HasErrorWithMessage("PTRACE_SETREGSET failed to write NT_PRSTATUS"));
+  EXPECT_THAT(state.BackupRegisters(pid),
+              HasErrorWithMessage("PTRACE_GETREGS, NT_PRSTATUS failed"));
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/WindowsUtils/BusyLoopLauncherTest.cpp
+++ b/src/WindowsUtils/BusyLoopLauncherTest.cpp
@@ -23,7 +23,7 @@ namespace orbit_windows_utils {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 [[nodiscard]] std::filesystem::path GetTestExecutablePath() {

--- a/src/WindowsUtils/CreateProcessTest.cpp
+++ b/src/WindowsUtils/CreateProcessTest.cpp
@@ -53,12 +53,12 @@ TEST(CreateProcess, WorkingDirectory) {
 TEST(CreateProcess, NonExistingExecutable) {
   const std::string executable = R"(C:\non_existing_executable.exe)";
   auto result = orbit_windows_utils::CreateProcess(executable, "", "");
-  EXPECT_THAT(result, orbit_test_utils::HasError("Executable does not exist"));
+  EXPECT_THAT(result, orbit_test_utils::HasErrorWithMessage("Executable does not exist"));
 }
 
 TEST(CreateProcess, NonExistingWorkingDirectory) {
   const std::string non_existing_working_directory = R"(C:\non_existing_directory)";
   auto result = orbit_windows_utils::CreateProcess(GetTestExecutablePath(),
                                                    non_existing_working_directory, "");
-  EXPECT_THAT(result, orbit_test_utils::HasError("Working directory does not exist"));
+  EXPECT_THAT(result, orbit_test_utils::HasErrorWithMessage("Working directory does not exist"));
 }

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -129,7 +129,7 @@ TEST(Debugger, NonExistingExecutable) {
   Debugger debugger({&listener});
   const std::string executable = R"(C:\non_existing_executable.exe)";
   auto result = debugger.Start(executable, "", "");
-  EXPECT_THAT(result, orbit_test_utils::HasError("Executable does not exist"));
+  EXPECT_THAT(result, orbit_test_utils::HasErrorWithMessage("Executable does not exist"));
 }
 
 TEST(Debugger, NonExistingWorkingDirectory) {
@@ -137,5 +137,5 @@ TEST(Debugger, NonExistingWorkingDirectory) {
   Debugger debugger({&listener});
   const std::string non_existing_working_directory = R"(C:\non_existing_directory)";
   auto result = debugger.Start(GetTestExecutablePath(), non_existing_working_directory, "");
-  EXPECT_THAT(result, orbit_test_utils::HasError("Working directory does not exist"));
+  EXPECT_THAT(result, orbit_test_utils::HasErrorWithMessage("Working directory does not exist"));
 }

--- a/src/WindowsUtils/DllInjectionTest.cpp
+++ b/src/WindowsUtils/DllInjectionTest.cpp
@@ -16,7 +16,7 @@
 
 namespace orbit_windows_utils {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 namespace {
@@ -37,7 +37,7 @@ TEST(DllInjection, InjectDllInCurrentProcess) {
 
   // Re-injection.
   result = InjectDll(pid, GetTestDllPath());
-  EXPECT_THAT(result, HasError("is already loaded in process"));
+  EXPECT_THAT(result, HasErrorWithMessage("is already loaded in process"));
 
   // GetRemoteProcAddress.
   ErrorMessageOr<uint64_t> remote_proc_result =
@@ -53,7 +53,7 @@ TEST(DllInjection, InjectDllInCurrentProcess) {
 TEST(DllInjection, InjectNonExistentDll) {
   uint32_t pid = orbit_base::GetCurrentProcessId();
   ErrorMessageOr<void> result = InjectDll(pid, GetNonExistentDllPath());
-  EXPECT_THAT(result, HasError("Path does not exist"));
+  EXPECT_THAT(result, HasErrorWithMessage("Path does not exist"));
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/FindDebugSymbolsTest.cpp
+++ b/src/WindowsUtils/FindDebugSymbolsTest.cpp
@@ -13,7 +13,7 @@
 
 namespace orbit_windows_utils {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasValue;
 
 TEST(ProcessServiceUtils, ExistingPdbFile) {
@@ -35,7 +35,7 @@ TEST(ProcessServiceUtils, CorruptedPdb) {
   // "other.pdb" is a text file that acts as a fake corrupted pdb.
   const ErrorMessageOr<std::filesystem::path> result =
       FindDebugSymbols(module_path, {test_directory / "additional_directory"});
-  EXPECT_THAT(result, HasError("does not contain symbols"));
+  EXPECT_THAT(result, HasErrorWithMessage("does not contain symbols"));
 }
 
 TEST(ProcessServiceUtils, FileDoesNotExist) {
@@ -44,7 +44,7 @@ TEST(ProcessServiceUtils, FileDoesNotExist) {
   const std::filesystem::path module_path = test_directory / "not_existing_file";
   const ErrorMessageOr<std::filesystem::path> result =
       FindDebugSymbols(module_path, {test_directory});
-  EXPECT_THAT(result, HasError("Unable to load"));
+  EXPECT_THAT(result, HasErrorWithMessage("Unable to load"));
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -16,7 +16,7 @@ namespace orbit_windows_utils {
 
 namespace {
 
-using orbit_test_utils::HasError;
+using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
 
 [[nodiscard]] std::filesystem::path GetTestExecutablePath() {
@@ -59,19 +59,19 @@ TEST(ProcessLauncher, LaunchNonExistingProcess) {
   auto result =
       launcher.LaunchProcess(non_existing_executable, /*working_directory=*/"", /*arguments=*/"",
                              /*pause_at_entry_point*/ false);
-  ASSERT_THAT(result, HasError("Executable does not exist"));
+  ASSERT_THAT(result, HasErrorWithMessage("Executable does not exist"));
 }
 
 TEST(ProcessLauncher, SuspendNonExistingProcess) {
   ProcessLauncher launcher;
   auto result = launcher.SuspendProcessSpinningAtEntryPoint(orbit_base::kInvalidProcessId);
-  ASSERT_THAT(result, HasError("Trying to suspend unknown process"));
+  ASSERT_THAT(result, HasErrorWithMessage("Trying to suspend unknown process"));
 }
 
 TEST(ProcessLauncher, ResumeNonExistingProcess) {
   ProcessLauncher launcher;
   auto result = launcher.ResumeProcessSuspendedAtEntryPoint(orbit_base::kInvalidProcessId);
-  ASSERT_THAT(result, HasError("Trying to resume unknown process"));
+  ASSERT_THAT(result, HasErrorWithMessage("Trying to resume unknown process"));
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/WriteProcessMemoryTest.cpp
+++ b/src/WindowsUtils/WriteProcessMemoryTest.cpp
@@ -39,5 +39,5 @@ TEST(WriteProcessMemory, WriteToInvalidMemoryLocation) {
   uint32_t pid = orbit_base::GetCurrentProcessId();
   const std::string test_string("The quick brown fox jumps over the lazy dog");
   auto result = orbit_windows_utils::WriteProcessMemory(pid, nullptr, test_string);
-  EXPECT_THAT(result, orbit_test_utils::HasError("Invalid access to memory location"));
+  EXPECT_THAT(result, orbit_test_utils::HasErrorWithMessage("Invalid access to memory location"));
 }


### PR DESCRIPTION
`HasError` is a GMock matcher that checks whether a result type contains
an error. When given a value matcher as an argument (`HasError(matcher)`),
the matcher is not applied to the actual error type but is expected to
be a string-like type and it will be checked if the given string is
contained in the error message.

This is surprising because that's not how all the other GMock matchers
work (See `testing::Optional` as an example.)

So this change renames the matcher to `HasErrorWithMessage` and adds a
new matcher `HasError` that works as described/expected. The matcher
given as an argument to `HasError` will be applied to the error type
of the result type (`ErrorMessage`, `Canceled`, and `NotFound` are our
most common error types.)

It also updated the implementation of `HasErrorWithMessage`. This now
uses matchers instead of `absl::StrContains` which results in better
error messages.