### PR TITLE
Integrate BatchGroup rendering into CaptureViewElement

### DIFF
--- a/src/OrbitGl/BatchRenderGroup.cpp
+++ b/src/OrbitGl/BatchRenderGroup.cpp
@@ -5,19 +5,25 @@
 #include "OrbitGl/BatchRenderGroup.h"
 
 namespace orbit_gl {
-StencilConfig& StencilConfig::ClipAt(const StencilConfig& parent) {
-  if (!parent.enabled) return *this;
-  if (!enabled) {
-    *this = parent;
-    return *this;
+StencilConfig ClipStencil(const StencilConfig& child, const StencilConfig& parent) {
+  if (!parent.enabled) return child;
+  if (!child.enabled) {
+    return parent;
   }
 
-  pos[0] = std::min(std::max(pos[0], parent.pos[0]), parent.pos[0] + parent.size[0]);
-  pos[1] = std::min(std::max(pos[1], parent.pos[1]), parent.pos[1] + parent.size[1]);
+  StencilConfig result = child;
 
-  size[0] = std::max(std::min(size[0], parent.pos[0] + parent.size[0] - pos[0]), 0.f);
-  size[1] = std::max(std::min(size[1], parent.pos[1] + parent.size[1] - pos[1]), 0.f);
+  Vec2 bottom_right = std::max(Vec2(child.pos + child.size), child.pos);
+  Vec2 parent_bottom_right = std::max(Vec2(parent.pos + parent.size), parent.pos);
 
-  return *this;
+  Vec2 pos = std::clamp(child.pos, parent.pos, parent_bottom_right);
+  bottom_right = std::clamp(bottom_right, parent.pos, parent_bottom_right);
+
+  Vec2 size = bottom_right - pos;
+
+  result.pos = pos;
+  result.size = size;
+
+  return result;
 }
 }  // namespace orbit_gl

--- a/src/OrbitGl/BatchRenderGroup.cpp
+++ b/src/OrbitGl/BatchRenderGroup.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGl/BatchRenderGroup.h"
+
+namespace orbit_gl {
+StencilConfig& StencilConfig::ClipAt(const StencilConfig& parent) {
+  if (!parent.enabled) return *this;
+  if (!enabled) {
+    *this = parent;
+    return *this;
+  }
+
+  pos[0] = std::min(std::max(pos[0], parent.pos[0]), parent.pos[0] + parent.size[0]);
+  pos[1] = std::min(std::max(pos[1], parent.pos[1]), parent.pos[1] + parent.size[1]);
+
+  size[0] = std::max(std::min(size[0], parent.pos[0] + parent.size[0] - pos[0]), 0.f);
+  size[1] = std::max(std::min(size[1], parent.pos[1] + parent.size[1] - pos[1]), 0.f);
+
+  return *this;
+}
+}  // namespace orbit_gl

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -103,7 +103,7 @@ target_sources(
           AsyncTrack.cpp
           BasicPageFaultsTrack.cpp
           Batcher.cpp
-          Batcher.cpp
+          BatchRenderGroup.cpp
           Button.cpp
           CallstackThreadBar.cpp
           CallTreeView.cpp

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -270,7 +270,7 @@ CaptureViewElement::RenderGroups CaptureViewElement::PreRender(
     state.stencil.pos = {GetPos()[0], GetPos()[1]};
     state.stencil.size = {GetSize()[0], GetSize()[1]};
     state.stencil.enabled = true;
-    state.stencil.ClipAt(parent_state.stencil);
+    state.stencil = ClipStencil(state.stencil, parent_state.stencil);
     manager->SetGroupState(new_batcher_render_group_name, state);
 
     const std::string new_text_render_group_name =
@@ -283,7 +283,7 @@ CaptureViewElement::RenderGroups CaptureViewElement::PreRender(
       state.stencil.pos = {GetPos()[0], GetPos()[1]};
       state.stencil.size = {GetSize()[0], GetSize()[1]};
       state.stencil.enabled = true;
-      state.stencil.ClipAt(parent_state.stencil);
+      state.stencil = ClipStencil(state.stencil, parent_state.stencil);
       manager->SetGroupState(new_text_render_group_name, state);
     }
   }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -858,7 +858,9 @@ void CaptureWindow::DrawLayerDebugInfo(
     painter->setFont(font);
     painter->setPen(QColor(255, 255, 255));
     const Vec2i pos = viewport_.WorldToScreen(Vec2(stencil.pos[0], stencil.pos[1]));
-    painter->drawText(pos[0], pos[1], 100, 20, Qt::AlignLeft, QString::fromStdString(group.name));
+    const Vec2i size = viewport_.WorldToScreen(Vec2(stencil.size[0], stencil.size[1]));
+    painter->drawText(pos[0], pos[1], size[0], size[1], Qt::AlignLeft,
+                      QString::fromStdString(group.name));
     painter->beginNativePainting();
   }
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -898,45 +898,6 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
     primitive_assembler.AddVerticalLine(green_line_pos, GetHeight(), GlCanvas::kZValueUi,
                                         white_line_color);
   }
-
-  // TODO(http://b/217719000): We are drawing boxes in margin positions because some elements are
-  // being drawn partially outside the TrackContainer space. This hack is needed until we assure
-  // that no element is drawn outside of its parent's area.
-  if (layout_->GetDrawTimeGraphMasks()) {
-    DrawMarginsBetweenChildren(primitive_assembler);
-  }
-}
-
-void TimeGraph::DrawMarginsBetweenChildren(
-    orbit_gl::PrimitiveAssembler& primitive_assembler) const {
-  // Margin between the Tracks and the Timeline.
-  Vec2 timeline_margin_pos = Vec2(GetPos()[0], GetPos()[1] + timeline_ui_->GetHeight());
-  Vec2 timeline_margin_size = Vec2(GetSize()[0], layout_->GetSpaceBetweenTracksAndTimeline());
-  primitive_assembler.AddBox(MakeBox(timeline_margin_pos, timeline_margin_size),
-                             GlCanvas::kZValueTimeBar, GlCanvas::kBackgroundColor);
-
-  // Right margin mask for Timegraph.
-  float right_margin_width = GetRightMargin();
-  float right_margin_height = GetHeight();
-  Vec2 right_margin_pos{GetWidth() - right_margin_width, GetPos()[1]};
-  Quad right_margin_box = MakeBox(right_margin_pos, Vec2(right_margin_width, right_margin_height));
-  primitive_assembler.AddBox(right_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor);
-
-  // Left margin mask for Timeline.
-  float left_margin_width = layout_->GetTrackHeaderWidth();
-  float left_margin_height = timeline_ui_->GetHeight();
-  Vec2 left_margin_pos = GetPos();
-  Quad left_margin_box = MakeBox(left_margin_pos, Vec2(left_margin_width, left_margin_height));
-  primitive_assembler.AddBox(left_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor);
-
-  // Left margin mask for horizontal slider.
-  float slider_height = layout_->GetSliderWidth();
-  Vec2 left_margin_slider_pos = GetPos();
-  left_margin_slider_pos[1] += (GetHeight() - slider_height);
-  Quad left_margin_box_slider =
-      MakeBox(left_margin_slider_pos, Vec2(left_margin_width, slider_height));
-  primitive_assembler.AddBox(left_margin_box_slider, GlCanvas::kZValueMargin,
-                             GlCanvas::kBackgroundColor);
 }
 
 bool TimeGraph::IsFullyVisible(uint64_t min, uint64_t max) const {

--- a/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
+++ b/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
@@ -61,6 +61,8 @@ struct StencilConfig {
   bool enabled = false;
   std::array<float, 2> pos = {0, 0};
   std::array<float, 2> size = {0, 0};
+
+  StencilConfig& ClipAt(const StencilConfig& parent);
 };
 
 // Collection of all properties that are associated with a BatchRenderGroup and that will influence

--- a/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
+++ b/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
@@ -64,11 +64,11 @@ struct StencilConfig {
   Vec2 pos = {0, 0};
   Vec2 size = {0, 0};
 
-  friend bool operator==(const StencilConfig& lhs, const StencilConfig& rhs) {
+  [[nodiscard]] friend bool operator==(const StencilConfig& lhs, const StencilConfig& rhs) {
     return std::tie(lhs.enabled, lhs.pos, lhs.size) == std::tie(rhs.enabled, rhs.pos, rhs.size);
   }
 
-  friend bool operator!=(const StencilConfig& lhs, const StencilConfig& rhs) {
+  [[nodiscard]] friend bool operator!=(const StencilConfig& lhs, const StencilConfig& rhs) {
     return !(lhs == rhs);
   }
 };
@@ -77,7 +77,7 @@ struct StencilConfig {
 // is not enabled, the child is returned. If the child is not enabled, it is assumed to be
 // equivalent to a bounding box of the whole domain, so it is still clipped to the parent and
 // enabled afterwards. Use this to ensure that child bounding boxes never exceed their parent's.
-StencilConfig ClipStencil(const StencilConfig& child, const StencilConfig& parent);
+[[nodiscard]] StencilConfig ClipStencil(const StencilConfig& child, const StencilConfig& parent);
 
 // Collection of all properties that are associated with a BatchRenderGroup and that will influence
 // how the group is rendered.

--- a/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
+++ b/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
@@ -67,6 +67,10 @@ struct StencilConfig {
   friend bool operator==(const StencilConfig& lhs, const StencilConfig& rhs) {
     return std::tie(lhs.enabled, lhs.pos, lhs.size) == std::tie(rhs.enabled, rhs.pos, rhs.size);
   }
+
+  friend bool operator!=(const StencilConfig& lhs, const StencilConfig& rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 // Returns a new StencilConfig that is the child clipped on the extents of the parent. If the parent

--- a/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
+++ b/src/OrbitGl/include/OrbitGl/BatchRenderGroup.h
@@ -5,9 +5,11 @@
 #ifndef ORBIT_GL_BATCH_RENDER_GROUP_H_
 #define ORBIT_GL_BATCH_RENDER_GROUP_H_
 
+#include <QRect>
 #include <functional>
 #include <string>
 
+#include "OrbitGl/CoreMath.h"
 #include "absl/container/flat_hash_map.h"
 
 namespace orbit_gl {
@@ -59,11 +61,19 @@ struct BatchRenderGroupId {
 // stores the extents of this box
 struct StencilConfig {
   bool enabled = false;
-  std::array<float, 2> pos = {0, 0};
-  std::array<float, 2> size = {0, 0};
+  Vec2 pos = {0, 0};
+  Vec2 size = {0, 0};
 
-  StencilConfig& ClipAt(const StencilConfig& parent);
+  friend bool operator==(const StencilConfig& lhs, const StencilConfig& rhs) {
+    return std::tie(lhs.enabled, lhs.pos, lhs.size) == std::tie(rhs.enabled, rhs.pos, rhs.size);
+  }
 };
+
+// Returns a new StencilConfig that is the child clipped on the extents of the parent. If the parent
+// is not enabled, the child is returned. If the child is not enabled, it is assumed to be
+// equivalent to a bounding box of the whole domain, so it is still clipped to the parent and
+// enabled afterwards. Use this to ensure that child bounding boxes never exceed their parent's.
+StencilConfig ClipStencil(const StencilConfig& child, const StencilConfig& parent);
 
 // Collection of all properties that are associated with a BatchRenderGroup and that will influence
 // how the group is rendered.

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -164,12 +164,32 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] virtual EventResult OnMouseEnter();
   [[nodiscard]] virtual EventResult OnMouseLeave();
 
+  // If TRUE, a new, uniquely named render group will be created for this element, and all of its
+  // content and that of its children will use this group for rendering. The content will also be
+  // restricted to the extents of the element automatically. By default, this returns false -
+  // override the method in a sub-class to change the behavior. Keep in mind that his has
+  // performance implications as it potentially adds a large number of render groups.
+  [[nodiscard]] virtual bool RequestSeparateRenderGroup() const { return false; }
+
+  [[nodiscard]] uint32_t GetUid() const { return uid_; }
+
  private:
   bool is_mouse_over_ = false;
+  uint32_t uid_;
 
   float width_ = 0.;
   Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;
+
+  struct RenderGroups {
+    std::string batcher_render_group_name;
+    std::string text_render_group_name;
+  };
+
+  [[nodiscard]] RenderGroups PreRender(PrimitiveAssembler& primitive_assembler,
+                                       TextRenderer& text_renderer);
+  void PostRender(RenderGroups&& previous_groups, PrimitiveAssembler& primitive_assembler,
+                  TextRenderer& text_renderer);
 
   friend class CaptureViewElementTester;
 };

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -167,8 +167,10 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   // If TRUE, a new, uniquely named render group will be created for this element, and all of its
   // content and that of its children will use this group for rendering. The content will also be
   // restricted to the extents of the element automatically. By default, this returns false -
-  // override the method in a sub-class to change the behavior. Keep in mind that this has
-  // performance implications as it potentially adds a large number of render groups.
+  // override the method in a sub-class to change the behavior.
+  // Keep in mind that adding a large number of groups may have performance and memory implications
+  // as the data inside each group is stored in a `BlockChain`, and very small groups will always
+  // reserve at least one block of memory. It also increases the number of draw calls.
   [[nodiscard]] virtual bool RequestSeparateRenderGroup() const { return false; }
 
   [[nodiscard]] uint32_t GetUid() const { return uid_; }

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -167,7 +167,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   // If TRUE, a new, uniquely named render group will be created for this element, and all of its
   // content and that of its children will use this group for rendering. The content will also be
   // restricted to the extents of the element automatically. By default, this returns false -
-  // override the method in a sub-class to change the behavior. Keep in mind that his has
+  // override the method in a sub-class to change the behavior. Keep in mind that this has
   // performance implications as it potentially adds a large number of render groups.
   [[nodiscard]] virtual bool RequestSeparateRenderGroup() const { return false; }
 

--- a/src/OrbitGl/include/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureWindow.h
@@ -91,6 +91,8 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;
 
+  uint last_rendered_layers_ = 0;
+
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;
 

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -222,8 +222,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) const;
 
-  void DrawMarginsBetweenChildren(orbit_gl::PrimitiveAssembler& primitive_assembler) const;
-
   [[nodiscard]] const TimerInfo* FindNextThreadTrackTimer(ScopeId scope_id, uint64_t current_time,
                                                           std::optional<uint32_t> thread_id) const;
 

--- a/src/OrbitGl/include/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/include/OrbitGl/TimelineUi.h
@@ -37,6 +37,8 @@ class TimelineUi : public CaptureViewElement {
 
   [[nodiscard]] float GetHeight() const override { return layout_->GetTimeBarHeight(); }
 
+  [[nodiscard]] bool RequestSeparateRenderGroup() const override { return true; }
+
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
  protected:

--- a/src/OrbitGl/include/OrbitGl/Track.h
+++ b/src/OrbitGl/include/OrbitGl/Track.h
@@ -111,6 +111,11 @@ class Track : public orbit_gl::CaptureViewElement,
 
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
+  [[nodiscard]] bool RequestSeparateRenderGroup() const override {
+    // Child tracks do not request their own groups
+    return GetIndentationLevel() == 0;
+  }
+
   // Must be overriden by child class for sensible behavior.
   [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const = 0;

--- a/src/OrbitGl/include/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/include/OrbitGl/TrackContainer.h
@@ -83,6 +83,8 @@ class TrackContainer final : public CaptureViewElement {
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetNonHiddenChildren() const override;
 
+  [[nodiscard]] bool RequestSeparateRenderGroup() const override { return true; }
+
  protected:
   void DoUpdateLayout() override;
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,


### PR DESCRIPTION
This adds a property `RequestSeparateRenderGroup` to `CaptureViewElement`.

If true, a `CaptureViewElement` will automatically create a new
render group with a unique name, and all of its contents and children
will be rendered in the new group, and all content will be restricted
to the extents of the element.

Performance [before](https://screenshot.googleplex.com/9sUXmnxpuNV9mEv) and [after](https://screenshot.googleplex.com/9yfx5DsaK7Dx2HM) (tl;dr: basically no difference).