### PR TITLE
Add debug layer rendering functionality

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -565,8 +565,6 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
     all_groups_sorted.erase(it, all_groups_sorted.end());
   }
 
-  last_rendered_layers_ = all_groups_sorted.size();
-
   if (time_graph_layout_->GetRenderDebugLayers() && picking_mode_ == PickingMode::kNone) {
     DrawLayerDebugInfo(all_groups_sorted, painter);
     return;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -565,6 +565,13 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
     all_groups_sorted.erase(it, all_groups_sorted.end());
   }
 
+  last_rendered_layers_ = all_groups_sorted.size();
+
+  if (time_graph_layout_->GetRenderDebugLayers() && picking_mode_ == PickingMode::kNone) {
+    DrawLayerDebugInfo(all_groups_sorted, painter);
+    return;
+  }
+
   for (const orbit_gl::BatchRenderGroupId& group : all_groups_sorted) {
     orbit_gl::StencilConfig stencil = render_group_manager_.GetGroupState(group.name).stencil;
     if (stencil.enabled) {
@@ -811,4 +818,42 @@ void CaptureWindow::RenderSelectionOverlay() {
   std::string text = orbit_display_formats::GetDisplayTime(TicksToDuration(min_time, max_time));
   text_renderer_.AddText(text.c_str(), stop_pos_world, select_stop_pos_world_[1],
                          GlCanvas::kZValueOverlay, formatting);
+}
+
+void CaptureWindow::DrawLayerDebugInfo(
+    const std::vector<orbit_gl::BatchRenderGroupId>& sorted_groups, QPainter* painter) {
+  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+
+  for (const auto& group : sorted_groups) {
+    const orbit_gl::StencilConfig& stencil =
+        render_group_manager_.GetGroupState(group.name).stencil;
+    if (!stencil.enabled) continue;
+
+    PrepareGlState();
+    if (time_graph_ != nullptr) {
+      const Color color = time_graph_->GetColor(static_cast<uint32_t>(
+          std::hash<std::string>()(group.name) % std::numeric_limits<uint32_t>::max()));
+      glColor4f(static_cast<float>(color[0]) / 255.f, static_cast<float>(color[1]) / 255.f,
+                static_cast<float>(color[2]) / 255.f, 1.f);
+    } else {
+      glColor4f(1, 0, 0, 1);
+    }
+    glBegin(GL_POLYGON);
+    {
+      glVertex2f(stencil.pos[0], stencil.pos[1]);
+      glVertex2f(stencil.pos[0] + stencil.size[0], stencil.pos[1]);
+      glVertex2f(stencil.pos[0] + stencil.size[0], stencil.pos[1] + stencil.size[1]);
+      glVertex2f(stencil.pos[0], stencil.pos[1] + stencil.size[1]);
+    }
+    glEnd();
+    CleanupGlState();
+
+    painter->endNativePainting();
+    font.setPixelSize(14);
+    painter->setFont(font);
+    painter->setPen(QColor(255, 255, 255));
+    const Vec2i pos = viewport_.WorldToScreen(Vec2(stencil.pos[0], stencil.pos[1]));
+    painter->drawText(pos[0], pos[1], 100, 20, Qt::AlignLeft, QString::fromStdString(group.name));
+    painter->beginNativePainting();
+  }
 }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -8,6 +8,7 @@
 #include <absl/container/btree_map.h>
 #include <absl/strings/str_format.h>
 
+#include <QFontDatabase>
 #include <QRect>
 #include <algorithm>
 #include <array>

--- a/src/OrbitGl/include/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureWindow.h
@@ -91,6 +91,8 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;
 
+  uint last_rendered_layers_ = 0;
+
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;
 

--- a/src/OrbitGl/include/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureWindow.h
@@ -91,8 +91,6 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;
 
-  uint last_rendered_layers_ = 0;
-
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;
 

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -108,6 +108,8 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   [[nodiscard]] bool GetDrawAsIfPicking() const override { return false; }
   [[nodiscard]] bool GetDrawTimeGraphMasks() const override { return false; }
 
+  [[nodiscard]] bool GetRenderDebugLayers() const override { return kRenderDebugLayers; }
+
  private:
   constexpr static float kTextBoxHeight = 20.f;
   constexpr static float kCoreHeight = 10.f;
@@ -150,6 +152,7 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   constexpr static float kThreadDependencyArrowBodyWidth = 4;
   constexpr static bool kDrawTrackBackground = true;
   constexpr static int kMaxLayoutingLoops = 10;
+  constexpr static bool kRenderDebugLayers = false;
 
   float scale_ = 1.f;
 };

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -49,6 +49,7 @@ class TimeGraphLayout {
   [[nodiscard]] virtual int GetMaxLayoutingLoops() const = 0;
   [[nodiscard]] virtual bool GetDrawAsIfPicking() const = 0;
   [[nodiscard]] virtual bool GetDrawTimeGraphMasks() const = 0;
+  [[nodiscard]] virtual bool GetRenderDebugLayers() const = 0;
   virtual void SetScale(float value) = 0;
   virtual void SetTrackHeaderWidth(float /*width*/){};
 

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -50,6 +50,7 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&draw_timegraph_masks_);
   AddWidgetForProperty(&draw_as_if_picking_);
   AddWidgetForProperty(&scale_);
+  AddWidgetForProperty(&render_debug_layers_);
 }
 
 float TimeGraphLayoutWidget::GetCollapseButtonSize(int indentation_level) const {

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -134,6 +134,8 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
 
   [[nodiscard]] bool GetDrawAsIfPicking() const override { return draw_as_if_picking_.value(); }
 
+  [[nodiscard]] bool GetRenderDebugLayers() const override { return render_debug_layers_.value(); }
+
  private:
   FloatProperty text_box_height_{{
       .initial_value = 20.f,
@@ -303,6 +305,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
 
   IntProperty max_layouting_loops_{
       {.initial_value = 10, .min = 1, .max = 100, .label = "Max layouting loops:"}};
+  BoolProperty render_debug_layers_{{.initial_value = false, .label = "Render Debug Layers"}};
 };
 
 }  // namespace orbit_qt


### PR DESCRIPTION
Adds a toggle to visualize all render groups that have a stencil
restriction to debug rendering issues:

![image](https://user-images.githubusercontent.com/63750742/214347215-5cdf7280-6243-4184-8181-18106aaf0710.png)