### PR TITLE
QVector build issue (#4750)

### DIFF
--- a/src/SessionSetup/ConnectToLocalWidget.cpp
+++ b/src/SessionSetup/ConnectToLocalWidget.cpp
@@ -126,7 +126,7 @@ void ConnectToLocalWidget::SetupProcessListUpdater() {
           std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (self == nullptr) return;
         emit self->ProcessListUpdated(
-	    QVector<orbit_grpc_protos::ProcessInfo>::fromStdVector(process_list));
+            QVector<orbit_grpc_protos::ProcessInfo>::fromStdVector(process_list));
       });
 }
 

--- a/src/SessionSetup/ConnectToLocalWidget.cpp
+++ b/src/SessionSetup/ConnectToLocalWidget.cpp
@@ -126,7 +126,7 @@ void ConnectToLocalWidget::SetupProcessListUpdater() {
           std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (self == nullptr) return;
         emit self->ProcessListUpdated(
-            QVector<orbit_grpc_protos::ProcessInfo>(process_list.begin(), process_list.end()));
+	    QVector<orbit_grpc_protos::ProcessInfo>::fromStdVector(process_list));
       });
 }
 


### PR DESCRIPTION
QVector has't got constructor from std::vector iterators, so
it's better to use static function: fromStdVector