### PR TITLE
Highlight track header on hover

### DIFF
--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -302,6 +302,14 @@ void PrimitiveAssembler::AddQuadBorder(const Quad& quad, float z, const Color& c
   AddLine(quad.vertices[3], quad.vertices[0], z, color);
 }
 
+void PrimitiveAssembler::AddAabbOutline(Vec2 pos, Vec2 size, float outline_width, float z,
+                                        const Color& color) {
+  AddBox(MakeBox(pos, {size[0], outline_width}), z, color);
+  AddBox(MakeBox({pos[0], pos[1] + size[1] - outline_width}, {size[0], outline_width}), z, color);
+  AddBox(MakeBox(pos, {outline_width, size[1]}), z, color);
+  AddBox(MakeBox({pos[0] + size[0] - outline_width, pos[1]}, {outline_width, size[1]}), z, color);
+}
+
 void PrimitiveAssembler::GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                                               ShadingDirection shading_direction) {
   constexpr float kGradientCoeff = 0.94f;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -82,6 +82,15 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
   // Draw track's content background.
   Quad box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight()));
   primitive_assembler.AddBox(box, track_z, track_background_color, shared_from_this());
+
+  // Track header highlight on hover.
+  if (IsMouseOver()) {
+    const Color kOutlineColor = Color(128, 128, 128, 255);
+    constexpr float kOutlineWidth = 2.f;
+    Vec2 outline_size = header_->GetSize() - Vec2{layout_->GetSpaceBetweenTracks(), 0};
+    primitive_assembler.AddAabbOutline(GetPos(), outline_size, kOutlineWidth,
+                                       GlCanvas::kZValueMargin, kOutlineColor);
+  }
 }
 
 void Track::DoUpdateLayout() {

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -85,7 +85,7 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
 
   // Track header highlight on hover.
   if (IsMouseOver()) {
-    const Color kOutlineColor = Color(128, 128, 128, 255);
+    static const Color kOutlineColor = Color(128, 128, 128, 255);
     constexpr float kOutlineWidth = 2.f;
     Vec2 outline_size = header_->GetSize() - Vec2{layout_->GetSpaceBetweenTracks(), 0};
     primitive_assembler.AddAabbOutline(GetPos(), outline_size, kOutlineWidth,

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -16,6 +16,7 @@
 #include "OrbitGl/TimeGraphLayout.h"
 #include "OrbitGl/Viewport.h"
 
+using orbit_gl::CaptureViewElement;
 using orbit_gl::PrimitiveAssembler;
 using orbit_gl::TextRenderer;
 
@@ -156,4 +157,16 @@ void Track::SetIndentationLevel(uint32_t level) {
 
   indentation_level_ = level;
   RequestUpdate();
+}
+
+CaptureViewElement::EventResult Track::OnMouseEnter() {
+  EventResult event_result = CaptureViewElement::OnMouseEnter();
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
+}
+
+CaptureViewElement::EventResult Track::OnMouseLeave() {
+  EventResult event_result = CaptureViewElement::OnMouseLeave();
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
 }

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -104,6 +104,7 @@ class PrimitiveAssembler {
   void AddQuadBorder(const Quad& quad, float z, const Color& color,
                      std::unique_ptr<orbit_gl::PickingUserData> user_data);
   void AddQuadBorder(const Quad& quad, float z, const Color& color);
+  void AddAabbOutline(Vec2 pos, Vec2 size, float outline_width, float z, const Color& color);
   void AddCircle(const Vec2& position, float radius, float z, const Color& color);
 
   enum class ArrowDirection { kUp, kDown };

--- a/src/OrbitGl/include/OrbitGl/Track.h
+++ b/src/OrbitGl/include/OrbitGl/Track.h
@@ -131,6 +131,9 @@ class Track : public orbit_gl::CaptureViewElement,
 
   virtual void UpdatePositionOfSubtracks() {}
 
+  [[nodiscard]] EventResult OnMouseEnter() override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
+
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
   bool pinned_ = false;


### PR DESCRIPTION
With the new vertical density, it is sometimes difficult to discern which track we are looking at. 
Add a highlight on the track header for the track that contains the mouse cursor.

See "ForwarderThread" track header:
![image](https://user-images.githubusercontent.com/3687222/214596245-db14b7e5-bac3-4827-a970-a19535ec6e80.png)
