### PR TITLE
Simplify inspection pathways

### DIFF
--- a/src/OrbitGl/SelectionData.cpp
+++ b/src/OrbitGl/SelectionData.cpp
@@ -29,7 +29,8 @@ SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureD
 }
 
 SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
-                             absl::Span<const CallstackEvent> callstack_events) {
+                             absl::Span<const CallstackEvent> callstack_events,
+                             SelectionType selection_type) {
   for (const CallstackEvent& event : callstack_events) {
     callstack_data_object_.AddCallstackFromKnownCallstackData(event,
                                                               capture_data.GetCallstackData());
@@ -40,4 +41,5 @@ SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureD
       post_processed_sampling_data_, module_manager, capture_data);
   bottom_up_view_ = CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
       post_processed_sampling_data_, module_manager, capture_data);
+  selection_type_ = selection_type;
 }

--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -23,7 +23,7 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/StopToken.h"
 #include "OrbitGl/CallTreeView.h"
-#include "OrbitGl/SamplingReport.h"
+#include "OrbitGl/SelectionData.h"
 
 namespace orbit_gl {
 
@@ -78,13 +78,7 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetCallstackInspection(
-      std::shared_ptr<const CallTreeView> top_down_view,
-      std::shared_ptr<const CallTreeView> bottom_up_view,
-      orbit_data_views::DataView* callstack_data_view,
-      const orbit_client_data::CallstackData* callstack_data,
-      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
-  virtual void ClearCallstackInspection() = 0;
+  virtual void SetSelection(SelectionData& selection_data) = 0;
 
   virtual bool IsConnected() = 0;
   [[nodiscard]] virtual bool IsLocalTarget() const = 0;
@@ -97,7 +91,6 @@ class MainWindowInterface {
   virtual void SetSelectionTopDownView(std::shared_ptr<const CallTreeView> view) = 0;
   virtual void SetSelectionBottomUpView(std::shared_ptr<const CallTreeView> view) = 0;
   virtual void SetSamplingReport(
-      orbit_data_views::DataView* callstack_data_view,
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
   virtual void SetSelectionSamplingReport(

--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -19,6 +19,7 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "CodeReport/CodeReport.h"
 #include "CodeReport/DisassemblyReport.h"
+#include "DataViews/DataViewType.h"
 #include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/StopToken.h"
@@ -78,7 +79,7 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetSelection(SelectionData& selection_data) = 0;
+  virtual void SetSelection(const SelectionData& selection_data) = 0;
 
   virtual bool IsConnected() = 0;
   [[nodiscard]] virtual bool IsLocalTarget() const = 0;

--- a/src/OrbitGl/include/OrbitGl/SelectionData.h
+++ b/src/OrbitGl/include/OrbitGl/SelectionData.h
@@ -21,6 +21,10 @@
 // This is meant to hold the data needed to update the data tabs to a specific selection.
 class SelectionData {
  public:
+  enum SelectionType {
+    kUnknown,
+    kInspection,
+  };
   // Delete move/copy operators because callstack_data_pointer_ is pointing to a variable inside the
   // class.
   SelectionData(const SelectionData& other) = delete;
@@ -35,7 +39,8 @@ class SelectionData {
 
   SelectionData(const orbit_client_data::ModuleManager& module_manager,
                 const orbit_client_data::CaptureData& capture_data,
-                absl::Span<const orbit_client_data::CallstackEvent> callstack_events);
+                absl::Span<const orbit_client_data::CallstackEvent> callstack_events,
+                SelectionType selection_type = kUnknown);
 
   std::shared_ptr<const CallTreeView> GetTopDownView() const { return top_down_view_; }
 
@@ -50,6 +55,8 @@ class SelectionData {
     return *callstack_data_pointer_;
   }
 
+  bool IsInspection() { return selection_type_ == kInspection; }
+
  private:
   std::shared_ptr<CallTreeView> top_down_view_;
   std::shared_ptr<CallTreeView> bottom_up_view_;
@@ -60,6 +67,8 @@ class SelectionData {
   // Depending on how SelectionData is created, this either points to callstack_data_object_ or to
   // the CallstackData object passed into SelectionData.
   const orbit_client_data::CallstackData* callstack_data_pointer_ = &callstack_data_object_;
+
+  SelectionType selection_type_ = kUnknown;
 };
 
 #endif  // CLIENT_DATA_SELECTION_DATA_H_

--- a/src/OrbitGl/include/OrbitGl/SelectionData.h
+++ b/src/OrbitGl/include/OrbitGl/SelectionData.h
@@ -21,10 +21,11 @@
 // This is meant to hold the data needed to update the data tabs to a specific selection.
 class SelectionData {
  public:
-  enum SelectionType {
+  enum class SelectionType {
     kUnknown,
     kInspection,
   };
+
   // Delete move/copy operators because callstack_data_pointer_ is pointing to a variable inside the
   // class.
   SelectionData(const SelectionData& other) = delete;
@@ -40,7 +41,7 @@ class SelectionData {
   SelectionData(const orbit_client_data::ModuleManager& module_manager,
                 const orbit_client_data::CaptureData& capture_data,
                 absl::Span<const orbit_client_data::CallstackEvent> callstack_events,
-                SelectionType selection_type = kUnknown);
+                SelectionType selection_type = SelectionType::kUnknown);
 
   std::shared_ptr<const CallTreeView> GetTopDownView() const { return top_down_view_; }
 
@@ -55,7 +56,7 @@ class SelectionData {
     return *callstack_data_pointer_;
   }
 
-  bool IsInspection() { return selection_type_ == kInspection; }
+  [[nodiscard]] bool IsInspection() const { return selection_type_ == SelectionType::kInspection; }
 
  private:
   std::shared_ptr<CallTreeView> top_down_view_;
@@ -68,7 +69,7 @@ class SelectionData {
   // the CallstackData object passed into SelectionData.
   const orbit_client_data::CallstackData* callstack_data_pointer_ = &callstack_data_object_;
 
-  SelectionType selection_type_ = kUnknown;
+  SelectionType selection_type_ = SelectionType::kUnknown;
 };
 
 #endif  // CLIENT_DATA_SELECTION_DATA_H_

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -126,6 +126,7 @@ void CallTreeWidget::SetCallTreeView(std::shared_ptr<const CallTreeView> call_tr
   ui_->callTreeTreeView->sortByColumn(CallTreeViewItemModel::kInclusive, Qt::DescendingOrder);
 
   OnSearchLineEditTextEdited(ui_->searchLineEdit->text());
+  OnSearchTypingFinishedTimerTimout();
 
   ResizeColumnsIfNecessary();
 }
@@ -238,21 +239,9 @@ void CallTreeWidget::SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_
   ui_->callTreeTreeView->hideColumn(CallTreeViewItemModel::kExclusive);
 }
 
-void CallTreeWidget::SetInspection(std::shared_ptr<const CallTreeView> call_tree_view) {
-  ORBIT_CHECK(hide_values_proxy_model_ != nullptr);
-  ui_->inspectionNoticeWidget->show();
-  inspection_model_ = std::make_unique<CallTreeViewItemModel>(std::move(call_tree_view));
-  hide_values_proxy_model_->setSourceModel(inspection_model_.get());
-  OnSearchTypingFinishedTimerTimout();
-}
+void CallTreeWidget::SetInspection() { ui_->inspectionNoticeWidget->show(); }
 
-void CallTreeWidget::ClearInspection() {
-  ORBIT_CHECK(hide_values_proxy_model_ != nullptr);
-  ui_->inspectionNoticeWidget->hide();
-  inspection_model_.reset();
-  hide_values_proxy_model_->setSourceModel(model_.get());
-  OnSearchTypingFinishedTimerTimout();
-}
+void CallTreeWidget::ClearInspection() { ui_->inspectionNoticeWidget->hide(); }
 
 void CallTreeWidget::resizeEvent(QResizeEvent* /*event*/) {
   if (column_resizing_state_ == ColumnResizingState::kInitial) {

--- a/src/OrbitQt/include/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/include/OrbitQt/CallTreeWidget.h
@@ -61,7 +61,7 @@ class CallTreeWidget : public QWidget {
   void SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_up_view);
   void ClearCallTreeView();
   // These methods can only be called after SetTopDownView or SetBottomUpView.
-  void SetInspection(std::shared_ptr<const CallTreeView> call_tree_view);
+  void SetInspection();
   void ClearInspection();
 
  protected:

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -85,7 +85,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void UpdatePanel(orbit_data_views::DataViewType type);
 
   void SetSamplingReport(
-      orbit_data_views::DataView* callstack_data_view,
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
   void SetSelectionSamplingReport(
@@ -147,14 +146,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetCallstackInspection(
-      std::shared_ptr<const CallTreeView> top_down_view,
-      std::shared_ptr<const CallTreeView> bottom_up_view,
-      orbit_data_views::DataView* callstack_data_view,
-      const orbit_client_data::CallstackData* callstack_data,
-      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
-
-  void ClearCallstackInspection() override;
+  void SetSelection(SelectionData& selection_data) override;
 
   bool IsConnected() override { return is_connected_; }
 

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -146,7 +146,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetSelection(SelectionData& selection_data) override;
+  void SetSelection(const SelectionData& selection_data) override;
 
   bool IsConnected() override { return is_connected_; }
 

--- a/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
@@ -48,10 +48,7 @@ class OrbitSamplingReport : public QWidget {
     return sampling_report_ != nullptr && sampling_report_->HasSamples();
   }
 
-  void SetInspection(
-      OrbitApp* app, orbit_data_views::DataView* callstack_data_view,
-      const orbit_client_data::CallstackData* callstack_data,
-      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
+  void SetInspection();
 
  signals:
   void LeaveCallstackInspectionClicked();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1911,7 +1911,7 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
             severity_name);
 }
 
-void OrbitMainWindow::SetSelection(SelectionData& selection_data) {
+void OrbitMainWindow::SetSelection(const SelectionData& selection_data) {
   SetTopDownView(selection_data.GetTopDownView());
   SetBottomUpView(selection_data.GetBottomUpView());
   SetSamplingReport(&selection_data.GetCallstackData(),

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -270,13 +270,6 @@ QPushButton:disabled {
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="OrbitSamplingReport" name="inspectionReport" native="true">
-            <property name="visible">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="topDownTab">

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -195,16 +195,7 @@ void OrbitSamplingReport::RefreshTabs() {
   }
 }
 
-void OrbitSamplingReport::SetInspection(
-    OrbitApp* app, orbit_data_views::DataView* callstack_data_view,
-    const orbit_client_data::CallstackData* callstack_data,
-    const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) {
-  Deinitialize();
-  Initialize(app, callstack_data_view, callstack_data, post_processed_sampling_data);
-  ui_->inspectionNoticeWidget->show();
-  RefreshCallstackView();
-  RefreshTabs();
-}
+void OrbitSamplingReport::SetInspection() { ui_->inspectionNoticeWidget->show(); }
 
 void OrbitSamplingReport::UpdateReport(
     const orbit_client_data::CallstackData* callstack_data,


### PR DESCRIPTION
This consolidates the way we set the sampling tabs to go through the same functions whether they are a time_range/thread selection or an inspection.