### PR TITLE
Add orbit_qt_utils::WaitFor

### DIFF
--- a/src/OrbitSshQt/TaskTest.cpp
+++ b/src/OrbitSshQt/TaskTest.cpp
@@ -64,6 +64,10 @@ TEST_F(SshTaskTest, Stdout) {
   QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdOut};
 
   EXPECT_THAT(WaitForWithTimeout(task.Start()), YieldsResult(HasNoError()));
+  // If we haven't yet received the `finished` signal, let's wait for it.
+  if (finished_signal.empty()) {
+    EXPECT_TRUE(finished_signal.wait());
+  }
   EXPECT_THAT(WaitForWithTimeout(task.Stop()), YieldsResult(HasNoError()));
 
   EXPECT_FALSE(ready_read_signal.empty());
@@ -76,6 +80,10 @@ TEST_F(SshTaskTest, Stderr) {
   QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdErr};
 
   EXPECT_THAT(WaitForWithTimeout(task.Start()), YieldsResult(HasNoError()));
+  // If we haven't yet received the `finished` signal, let's wait for it.
+  if (finished_signal.empty()) {
+    EXPECT_TRUE(finished_signal.wait());
+  }
   EXPECT_THAT(WaitForWithTimeout(task.Stop()), YieldsResult(HasNoError()));
 
   EXPECT_GE(ready_read_signal.size(), 1);

--- a/src/QtTestUtils/include/QtTestUtils/WaitForWithTimeout.h
+++ b/src/QtTestUtils/include/QtTestUtils/WaitForWithTimeout.h
@@ -8,11 +8,11 @@
 #include <absl/time/time.h>
 #include <gmock/gmock.h>
 
-#include <QTest>
 #include <chrono>
 
 #include "OrbitBase/Result.h"
 #include "QtUtils/CreateTimeout.h"
+#include "QtUtils/WaitFor.h"
 
 namespace orbit_qt_test_utils {
 
@@ -20,22 +20,13 @@ template <typename T>
 orbit_qt_utils::TimeoutOr<T> WaitForWithTimeout(
     const orbit_base::Future<T>& future,
     std::chrono::milliseconds timeout = std::chrono::milliseconds{5000}) {
-  if (QTest::qWaitFor([&future]() { return future.IsFinished(); },
-                      static_cast<int>(timeout.count()))) {
-    if constexpr (std::is_same_v<T, void>) {
-      return outcome::success();
-    } else {
-      return future.Get();
-    }
-  }
-
-  return orbit_qt_utils::Timeout{};
+  return orbit_qt_utils::WaitFor(orbit_qt_utils::WhenValueOrTimeout(future, timeout));
 }
 
 template <typename T>
 orbit_qt_utils::TimeoutOr<T> WaitForWithTimeout(const orbit_base::Future<T>& future,
                                                 absl::Duration timeout) {
-  return WaitForWithTimeout(future, absl::ToChronoMilliseconds(timeout));
+  return orbit_qt_utils::WaitFor(orbit_qt_utils::WhenValueOrTimeout(future, timeout));
 }
 
 MATCHER(YieldsTimeout, "") {

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -24,7 +24,8 @@ target_sources(QtUtils PUBLIC include/QtUtils/AssertNoQtLogWarnings.h
                               include/QtUtils/ExecuteProcess.h
                               include/QtUtils/MainThreadExecutor.h
                               include/QtUtils/SingleThreadExecutor.h
-                              include/QtUtils/Throttle.h)
+                              include/QtUtils/Throttle.h
+                              include/QtUtils/WaitFor.h)
 
 target_sources(QtUtils PRIVATE ExecuteProcess.cpp
                                MainThreadExecutor.cpp
@@ -43,6 +44,7 @@ target_sources(QtUtilsTests PRIVATE CreateTimeoutTest.cpp
                                     ExecuteProcessTest.cpp
                                     MainThreadExecutorTest.cpp
                                     SingleThreadExecutorTest.cpp
-                                    ThrottleTest.cpp)
+                                    ThrottleTest.cpp
+                                    WaitForTest.cpp)
 target_link_libraries(QtUtilsTests PRIVATE TestUtils QtTestUtils QtUtils GTest::QtCoreMain)
 register_test(QtUtilsTests)

--- a/src/QtUtils/WaitForTest.cpp
+++ b/src/QtUtils/WaitForTest.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QMetaObject>
+
+#include "OrbitBase/Promise.h"
+#include "QtUtils/WaitFor.h"
+
+namespace orbit_qt_utils {
+
+TEST(WaitFor, PendingFutureOfInt) {
+  orbit_base::Promise<int> promise{};
+
+  // We schedule a task on the event loop. This task will be executed when `WaitFor` processes
+  // events while waiting.
+  QObject context{};
+  QMetaObject::invokeMethod(
+      &context, [&]() { promise.SetResult(42); }, Qt::QueuedConnection);
+
+  EXPECT_THAT(WaitFor(promise.GetFuture()), testing::Eq(42));
+}
+
+TEST(WaitFor, PendingFutureOfVoid) {
+  orbit_base::Promise<void> promise{};
+
+  // We schedule a task on the event loop. This task will be executed when `WaitFor` processes
+  // events while waiting.
+  QObject context{};
+  QMetaObject::invokeMethod(
+      &context, [&]() { promise.MarkFinished(); }, Qt::QueuedConnection);
+
+  WaitFor(promise.GetFuture());
+  SUCCEED();
+}
+
+TEST(WaitFor, CompletedFutureOfInt) {
+  orbit_base::Promise<int> promise{};
+  promise.SetResult(42);
+
+  // We schedule a task on the event loop that we don't expect to be executed.
+  QObject context{};
+  QMetaObject::invokeMethod(
+      &context, []() { FAIL(); }, Qt::QueuedConnection);
+
+  // The returned future is already completed, so `WaitFor` will not process any scheduled tasks.
+  EXPECT_THAT(WaitFor(promise.GetFuture()), testing::Eq(42));
+}
+
+TEST(WaitFor, CompletedFutureOfVoid) {
+  orbit_base::Promise<void> promise{};
+  promise.MarkFinished();
+
+  // We schedule a task on the event loop that we don't expect to be executed.
+  QObject context{};
+  QMetaObject::invokeMethod(
+      &context, []() { FAIL(); }, Qt::QueuedConnection);
+
+  // The returned future is already completed, so `WaitFor` will not process any scheduled tasks.
+  WaitFor(promise.GetFuture());
+  SUCCEED();
+}
+
+}  // namespace orbit_qt_utils

--- a/src/QtUtils/include/QtUtils/WaitFor.h
+++ b/src/QtUtils/include/QtUtils/WaitFor.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef QT_UTILS_WAIT_FOR_H_
+#define QT_UTILS_WAIT_FOR_H_
+
+#include <OrbitBase/Future.h>
+#include <qnamespace.h>
+
+#include <QEventLoop>
+#include <QMetaObject>
+#include <tuple>
+
+#include "OrbitBase/ImmediateExecutor.h"
+
+namespace orbit_qt_utils {
+
+// Blocks until `future` completes and then returns the stored value. While blocking this function
+// spins up a Qt Event Loop and processes Qt events.
+//
+// If the future is already completed when this function is called, it is guaranteed that no event
+// processing takes place and the function returns right away.
+template <typename T>
+T WaitFor(const orbit_base::Future<T>& future) {
+  if (future.IsFinished()) return future.Get();
+
+  QEventLoop event_loop{};
+  std::optional<T> return_value;
+
+  orbit_base::ImmediateExecutor immediate_executor{};
+  std::ignore = future.Then(&immediate_executor, [&](const T& value) {
+    // `return_value` might be written from a different thread, but since we won't access the
+    // variable before the `event_loop` returns, this is fine. The `invokeMethod` call below is
+    // thread-safe.
+    return_value.emplace(value);
+    QMetaObject::invokeMethod(&event_loop, &QEventLoop::quit, Qt::QueuedConnection);
+  });
+  event_loop.exec();
+  return std::move(return_value.value());
+}
+
+// Overload of previous function for `Future<void>`. Check out the previous overload for details.
+inline void WaitFor(const orbit_base::Future<void>& future) {
+  if (future.IsFinished()) return;
+
+  QEventLoop event_loop{};
+
+  orbit_base::ImmediateExecutor immediate_executor{};
+  std::ignore = future.Then(&immediate_executor, [&]() {
+    // This lambda might be executed on a different thread which is no problem because the
+    // `invokeMethod` call is thread-safe.
+    QMetaObject::invokeMethod(&event_loop, &QEventLoop::quit, Qt::QueuedConnection);
+  });
+  event_loop.exec();
+}
+}  // namespace orbit_qt_utils
+
+#endif  // QT_UTILS_WAIT_FOR_H_


### PR DESCRIPTION
This replaces the waiting functionality what has previously been provided by `FutureWatcher`.

The main difference is that wait operations from
`orbit_qt_utils::WaitFor` can't be aborted which makes it a lot easier to reason about them when used in code.

Cancelation and Timeouts can still be achieved by combining with `WhenValueOrCanceled` or `WhenValueOrTimeout` free functions.

The change also replaces the implementation of `orbit_qt_test_utils::WaitForWithTimeout`. Its custom implementation can now be composed from `WaitFor` and `WhenValueOrTimeout`.