### PR TITLE
Add WhenValueOrCanceled

### DIFF
--- a/src/OrbitBase/include/OrbitBase/StopToken.h
+++ b/src/OrbitBase/include/OrbitBase/StopToken.h
@@ -6,9 +6,13 @@
 #define ORBIT_BASE_STOP_TOKEN_H_
 
 #include <memory>
+#include <variant>
 
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
+#include "OrbitBase/ImmediateExecutor.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/WhenAny.h"
 
 namespace orbit_base {
 
@@ -35,6 +39,34 @@ class StopToken {
 
   orbit_base::Future<void> future_;
 };
+
+// Takes a `Future<T>` and a `StopToken` and returns a `Future<CanceledOr<T>>`. The returned future
+// will complete when either the input future completes or when the StopToken indicates that a stop
+// was requested - whatever happens first. When a stop was requested the resulting value will be
+// marked as `Canceled`, otherwise it will contain the `T`.
+//
+// Note that this doesn't mean that the operation that was supposed to produce the result of
+// `Future<T>` will be interrupted. It will finish as usual, but the result will not be used
+// by this code path.
+// To make a background job truly cancelable you have to make the task take a StopToken instead.
+//
+// This function is still useful though to make an uninterruptable task "cancelable".
+template <typename T>
+auto WhenValueOrCanceled(const Future<T>& value, const StopToken& stop_token)
+    -> Future<CanceledOr<T>> {
+  orbit_base::ImmediateExecutor executor{};
+  return orbit_base::WhenAny(value, stop_token.GetFuture())
+      .Then(&executor,
+            [](const std::variant<orbit_base::VoidToMonostate_t<T>, std::monostate>& result)
+                -> CanceledOr<T> {
+              if (result.index() == 1) return outcome::failure(Canceled{});
+              if constexpr (std::is_same_v<T, void>) {
+                return outcome::success();
+              } else {
+                return outcome::success(std::get<0>(result));
+              }
+            });
+}
 
 }  // namespace orbit_base
 


### PR DESCRIPTION
This adds a helper function which takes a `StopToken` and a future and returns a future that completes when either the StopToken indicates a requested stop or the future completes.

It's helpful to make futures appear "cancelable" and to write more readable code with clear intent.

The implementation is basically a copy of `WhenValueOrTimeout`.