### PR TITLE
Deinitialize orbitsamplingreport before destroying

### DIFF
--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -55,7 +55,10 @@ OrbitSamplingReport::OrbitSamplingReport(QWidget* parent)
           &OrbitSamplingReport::OnCurrentThreadTabChanged);
 }
 
-OrbitSamplingReport::~OrbitSamplingReport() { delete ui_; }
+OrbitSamplingReport::~OrbitSamplingReport() {
+  Deinitialize();
+  delete ui_;
+}
 
 void OrbitSamplingReport::Initialize(
     OrbitApp* app, orbit_data_views::DataView* callstack_data_view,


### PR DESCRIPTION
This prevents a crash where callstack data view thinks it has data when it doesn't by clearing the callstack data view. It calls ClearReport of the sampling report which then calls ClearCallstack for the callstack data view.

This probably needs to be cleaned up/refactor more to make this ownership more clear as it is currently confusing as to who should own this between SamplingReport, OrbitApp, and orbitsamplingreport. However, this is good in preventing the crash introduced in PR #4712.