### PR TITLE
Remove string members from CallTreeView

### DIFF
--- a/src/ClientData/include/ClientData/CaptureDataHolder.h
+++ b/src/ClientData/include/ClientData/CaptureDataHolder.h
@@ -38,6 +38,10 @@ class CaptureDataHolder {
     ORBIT_CHECK(HasCaptureData());
     return *capture_data_;
   }
+  [[nodiscard]] const CaptureData* GetCaptureDataPointer() const {
+    ORBIT_CHECK(HasCaptureData());
+    return capture_data_.get();
+  }
 
   [[nodiscard]] std::optional<ScopeId> ProvideScopeId(
       const orbit_client_protos::TimerInfo& timer_info) const {

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -217,7 +217,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
   ORBIT_SCOPE_FUNCTION;
   ORBIT_SCOPED_TIMED_LOG("CreateTopDownViewFromPostProcessedSamplingData");
 
-  std::unique_ptr<CallTreeRoot> top_down_view_root = std::make_unique<CallTreeRoot>();
+  auto top_down_view_root = std::make_unique<CallTreeRoot>();
   const std::string& process_name = capture_data->process_name();
   const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data->thread_names();
 
@@ -247,8 +247,8 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
       }
     }
   }
-  return std::make_unique<CallTreeView>(std::move(top_down_view_root), module_manager,
-                                        capture_data);
+  return absl::WrapUnique<CallTreeView>(
+      new CallTreeView(std::move(top_down_view_root), module_manager, capture_data));
 }
 
 [[nodiscard]] static CallTreeNode* AddReversedCallstackToBottomUpViewAndReturnLastFunction(
@@ -292,7 +292,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
   ORBIT_SCOPE_FUNCTION;
   ORBIT_SCOPED_TIMED_LOG("CreateBottomUpViewFromPostProcessedSamplingData");
 
-  std::unique_ptr<CallTreeRoot> bottom_up_view_root = std::make_unique<CallTreeRoot>();
+  auto bottom_up_view_root = std::make_unique<CallTreeRoot>();
   const std::string& process_name = capture_data->process_name();
   const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data->thread_names();
 
@@ -325,6 +325,6 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
     }
   }
 
-  return std::make_unique<CallTreeView>(std::move(bottom_up_view_root), module_manager,
-                                        capture_data);
+  return absl::WrapUnique<CallTreeView>(
+      new CallTreeView(std::move(bottom_up_view_root), module_manager, capture_data));
 }

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -1015,8 +1015,7 @@ void OrbitApp::ClearSelectionReport() {
 }
 
 void OrbitApp::ClearTopDownView() {
-  main_window_->SetTopDownView(
-      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
+  main_window_->SetTopDownView(std::make_unique<CallTreeView>());
 }
 
 void OrbitApp::SetSelectionTopDownView(
@@ -1029,13 +1028,11 @@ void OrbitApp::SetSelectionTopDownView(
 }
 
 void OrbitApp::ClearSelectionTopDownView() {
-  main_window_->SetSelectionTopDownView(
-      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
+  main_window_->SetSelectionTopDownView(std::make_unique<CallTreeView>());
 }
 
 void OrbitApp::ClearBottomUpView() {
-  main_window_->SetBottomUpView(
-      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
+  main_window_->SetBottomUpView(std::make_unique<CallTreeView>());
 }
 
 void OrbitApp::SetSelectionBottomUpView(
@@ -1048,8 +1045,7 @@ void OrbitApp::SetSelectionBottomUpView(
 }
 
 void OrbitApp::ClearSelectionBottomUpView() {
-  main_window_->SetSelectionBottomUpView(
-      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
+  main_window_->SetSelectionBottomUpView(std::make_unique<CallTreeView>());
 }
 
 absl::Duration OrbitApp::GetCaptureTime() const {

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -1015,7 +1015,8 @@ void OrbitApp::ClearSelectionReport() {
 }
 
 void OrbitApp::ClearTopDownView() {
-  main_window_->SetTopDownView(std::make_unique<CallTreeView>(nullptr, nullptr));
+  main_window_->SetTopDownView(
+      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
 }
 
 void OrbitApp::SetSelectionTopDownView(
@@ -1028,11 +1029,13 @@ void OrbitApp::SetSelectionTopDownView(
 }
 
 void OrbitApp::ClearSelectionTopDownView() {
-  main_window_->SetSelectionTopDownView(std::make_unique<CallTreeView>(nullptr, nullptr));
+  main_window_->SetSelectionTopDownView(
+      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
 }
 
 void OrbitApp::ClearBottomUpView() {
-  main_window_->SetBottomUpView(std::make_unique<CallTreeView>(nullptr, nullptr));
+  main_window_->SetBottomUpView(
+      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
 }
 
 void OrbitApp::SetSelectionBottomUpView(
@@ -1045,7 +1048,8 @@ void OrbitApp::SetSelectionBottomUpView(
 }
 
 void OrbitApp::ClearSelectionBottomUpView() {
-  main_window_->SetSelectionBottomUpView(std::make_unique<CallTreeView>(nullptr, nullptr));
+  main_window_->SetSelectionBottomUpView(
+      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr));
 }
 
 absl::Duration OrbitApp::GetCaptureTime() const {

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -439,8 +439,8 @@ Future<void> OrbitApp::OnCaptureComplete() {
         RefreshCaptureView();
 
         full_capture_selection_ = std::make_unique<SelectionData>(
-            *module_manager_, GetCaptureData(), GetCaptureData().post_processed_sampling_data(),
-            &GetCaptureData().GetCallstackData());
+            module_manager_.get(), GetCaptureDataPointer(),
+            GetCaptureData().post_processed_sampling_data(), &GetCaptureData().GetCallstackData());
         main_window_->SetSelection(*full_capture_selection_);
 
         ORBIT_CHECK(capture_stopped_callback_);
@@ -1015,37 +1015,37 @@ void OrbitApp::ClearSelectionReport() {
 }
 
 void OrbitApp::ClearTopDownView() {
-  main_window_->SetTopDownView(std::make_unique<CallTreeView>());
+  main_window_->SetTopDownView(std::make_unique<CallTreeView>(nullptr, nullptr));
 }
 
 void OrbitApp::SetSelectionTopDownView(
     const PostProcessedSamplingData& selection_post_processed_data,
-    const CaptureData& capture_data) {
+    const CaptureData* capture_data) {
   std::unique_ptr<CallTreeView> selection_top_down_view =
-      CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(selection_post_processed_data,
-                                                                   *module_manager_, capture_data);
+      CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+          selection_post_processed_data, module_manager_.get(), capture_data);
   main_window_->SetSelectionTopDownView(std::move(selection_top_down_view));
 }
 
 void OrbitApp::ClearSelectionTopDownView() {
-  main_window_->SetSelectionTopDownView(std::make_unique<CallTreeView>());
+  main_window_->SetSelectionTopDownView(std::make_unique<CallTreeView>(nullptr, nullptr));
 }
 
 void OrbitApp::ClearBottomUpView() {
-  main_window_->SetBottomUpView(std::make_unique<CallTreeView>());
+  main_window_->SetBottomUpView(std::make_unique<CallTreeView>(nullptr, nullptr));
 }
 
 void OrbitApp::SetSelectionBottomUpView(
     const PostProcessedSamplingData& selection_post_processed_data,
-    const CaptureData& capture_data) {
+    const CaptureData* capture_data) {
   std::unique_ptr<CallTreeView> selection_bottom_up_view =
-      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(selection_post_processed_data,
-                                                                    *module_manager_, capture_data);
+      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+          selection_post_processed_data, module_manager_.get(), capture_data);
   main_window_->SetSelectionBottomUpView(std::move(selection_bottom_up_view));
 }
 
 void OrbitApp::ClearSelectionBottomUpView() {
-  main_window_->SetSelectionBottomUpView(std::make_unique<CallTreeView>());
+  main_window_->SetSelectionBottomUpView(std::make_unique<CallTreeView>(nullptr, nullptr));
 }
 
 absl::Duration OrbitApp::GetCaptureTime() const {
@@ -1419,14 +1419,13 @@ void OrbitApp::ClearCapture() {
   if (capture_window_ != nullptr) {
     capture_window_->ClearTimeGraph();
   }
+  ClearSamplingRelatedViews();
   ResetCaptureData();
 
   string_manager_.Clear();
 
   set_selected_thread_id(orbit_base::kAllProcessThreadsTid);
   SelectTimer(nullptr);
-
-  UpdateAfterCaptureCleared();
 
   main_window_->OnCaptureCleared();
 
@@ -2267,18 +2266,18 @@ void OrbitApp::SetCaptureDataSelectionFields(
 void OrbitApp::SelectCallstackEvents(absl::Span<const CallstackEvent> selected_callstack_events) {
   SetCaptureDataSelectionFields(selected_callstack_events);
   SetSelectionTopDownView(GetCaptureData().selection_post_processed_sampling_data(),
-                          GetCaptureData());
+                          GetCaptureDataPointer());
   SetSelectionBottomUpView(GetCaptureData().selection_post_processed_sampling_data(),
-                           GetCaptureData());
+                           GetCaptureDataPointer());
   SetSelectionReport(&GetCaptureData().selection_callstack_data(),
                      &GetCaptureData().selection_post_processed_sampling_data());
   FireRefreshCallbacks();
 }
 
 void OrbitApp::InspectCallstackEvents(absl::Span<const CallstackEvent> selected_callstack_events) {
-  auto selection =
-      std::make_unique<SelectionData>(*module_manager_, GetCaptureData(), selected_callstack_events,
-                                      SelectionData::SelectionType::kInspection);
+  auto selection = std::make_unique<SelectionData>(module_manager_.get(), GetCaptureDataPointer(),
+                                                   selected_callstack_events,
+                                                   SelectionData::SelectionType::kInspection);
   main_window_->SetSelection(*selection);
   inspection_selection_ = std::move(selection);
   FireRefreshCallbacks();
@@ -2314,7 +2313,7 @@ void OrbitApp::UpdateAfterSymbolLoading() {
       orbit_client_model::CreatePostProcessedSamplingData(capture_data.GetCallstackData(),
                                                           capture_data, *module_manager_);
   GetMutableCaptureData().set_post_processed_sampling_data(post_processed_sampling_data);
-  auto selection = std::make_unique<SelectionData>(*module_manager_, GetCaptureData(),
+  auto selection = std::make_unique<SelectionData>(module_manager_.get(), GetCaptureDataPointer(),
                                                    GetCaptureData().post_processed_sampling_data(),
                                                    &GetCaptureData().GetCallstackData());
   main_window_->SetSelection(*selection);
@@ -2328,15 +2327,15 @@ void OrbitApp::UpdateAfterSymbolLoading() {
   GetMutableCaptureData().set_selection_post_processed_sampling_data(
       std::move(selection_post_processed_sampling_data));
 
-  SetSelectionTopDownView(capture_data.selection_post_processed_sampling_data(), capture_data);
-  SetSelectionBottomUpView(capture_data.selection_post_processed_sampling_data(), capture_data);
+  SetSelectionTopDownView(capture_data.selection_post_processed_sampling_data(), &capture_data);
+  SetSelectionBottomUpView(capture_data.selection_post_processed_sampling_data(), &capture_data);
   main_window_->UpdateSelectionReport(&capture_data.selection_callstack_data(),
                                       &capture_data.selection_post_processed_sampling_data());
 }
 
 void OrbitApp::UpdateAfterSymbolLoadingThrottled() { update_after_symbol_loading_throttle_.Fire(); }
 
-void OrbitApp::UpdateAfterCaptureCleared() {
+void OrbitApp::ClearSamplingRelatedViews() {
   ClearSamplingReport();
   ClearSelectionReport();
   ClearTopDownView();
@@ -2843,8 +2842,8 @@ void OrbitApp::OnThreadOrTimeRangeSelectionChange() {
     callstack_events = GetCaptureData().GetCallstackData().GetCallstackEventsOfTidInTimeRange(
         thread_id, time_range.start, time_range.end);
   }
-  auto selection =
-      std::make_unique<SelectionData>(*module_manager_, GetCaptureData(), callstack_events);
+  auto selection = std::make_unique<SelectionData>(module_manager_.get(), GetCaptureDataPointer(),
+                                                   callstack_events);
   main_window_->SetLiveTabScopeStatsCollection(
       GetCaptureData().CreateScopeStatsCollection(thread_id, time_range.start, time_range.end));
   main_window_->SetSelection(*selection);

--- a/src/OrbitGl/SelectionData.cpp
+++ b/src/OrbitGl/SelectionData.cpp
@@ -17,7 +17,7 @@ using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::PostProcessedSamplingData;
 
-SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
+SelectionData::SelectionData(const ModuleManager* module_manager, const CaptureData* capture_data,
                              PostProcessedSamplingData post_processed_sampling_data,
                              const CallstackData* callstack_data)
     : post_processed_sampling_data_(std::move(post_processed_sampling_data)),
@@ -28,15 +28,15 @@ SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureD
       post_processed_sampling_data_, module_manager, capture_data);
 }
 
-SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
+SelectionData::SelectionData(const ModuleManager* module_manager, const CaptureData* capture_data,
                              absl::Span<const CallstackEvent> callstack_events,
                              SelectionType selection_type) {
   for (const CallstackEvent& event : callstack_events) {
     callstack_data_object_.AddCallstackFromKnownCallstackData(event,
-                                                              capture_data.GetCallstackData());
+                                                              capture_data->GetCallstackData());
   }
   post_processed_sampling_data_ = orbit_client_model::CreatePostProcessedSamplingData(
-      callstack_data_object_, capture_data, module_manager);
+      callstack_data_object_, *capture_data, *module_manager);
   top_down_view_ = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
       post_processed_sampling_data_, module_manager, capture_data);
   bottom_up_view_ = CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -219,14 +219,14 @@ class OrbitApp final : public DataViewFactory,
   void ClearTopDownView();
   void SetSelectionTopDownView(
       const orbit_client_data::PostProcessedSamplingData& selection_post_processed_data,
-      const orbit_client_data::CaptureData& capture_data);
+      const orbit_client_data::CaptureData* capture_data);
   void ClearSelectionTopDownView();
 
   void SetBottomUpView(const orbit_client_data::PostProcessedSamplingData& post_processed_data);
   void ClearBottomUpView();
   void SetSelectionBottomUpView(
       const orbit_client_data::PostProcessedSamplingData& selection_post_processed_data,
-      const orbit_client_data::CaptureData& capture_data);
+      const orbit_client_data::CaptureData* capture_data);
   void ClearSelectionBottomUpView();
 
   // This needs to be called from the main thread.
@@ -277,7 +277,7 @@ class OrbitApp final : public DataViewFactory,
 
   void UpdateAfterSymbolLoading();
   void UpdateAfterSymbolLoadingThrottled();
-  void UpdateAfterCaptureCleared();
+  void ClearSamplingRelatedViews();
 
   // Load the functions and add frame tracks from a particular module of a preset file.
   orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(

--- a/src/OrbitGl/include/OrbitGl/SelectionData.h
+++ b/src/OrbitGl/include/OrbitGl/SelectionData.h
@@ -33,13 +33,13 @@ class SelectionData {
   SelectionData(SelectionData&& other) = delete;
   SelectionData& operator=(SelectionData&& other) = delete;
 
-  SelectionData(const orbit_client_data::ModuleManager& module_manager,
-                const orbit_client_data::CaptureData& capture_data,
+  SelectionData(const orbit_client_data::ModuleManager* module_manager,
+                const orbit_client_data::CaptureData* capture_data,
                 orbit_client_data::PostProcessedSamplingData post_processed_sampling_data,
                 const orbit_client_data::CallstackData* callstack_data);
 
-  SelectionData(const orbit_client_data::ModuleManager& module_manager,
-                const orbit_client_data::CaptureData& capture_data,
+  SelectionData(const orbit_client_data::ModuleManager* module_manager,
+                const orbit_client_data::CaptureData* capture_data,
                 absl::Span<const orbit_client_data::CallstackEvent> callstack_events,
                 SelectionType selection_type = SelectionType::kUnknown);
 

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -61,7 +61,7 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
   } else if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->function_name());
+        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
       case kInclusive:
         return QString::fromStdString(absl::StrFormat(
             "%.2f%% (%llu)", function_item->GetInclusivePercent(call_tree_view_->sample_count()),
@@ -74,7 +74,7 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
         return QString::fromStdString(
             absl::StrFormat("%.2f%%", function_item->GetPercentOfParent()));
       case kModule:
-        return QString::fromStdString(function_item->GetModuleName());
+        return QString::fromStdString(function_item->RetrieveModuleName(*call_tree_view_));
       case kFunctionAddress:
         return QString::fromStdString(
             absl::StrFormat("%#llx", function_item->function_absolute_address()));
@@ -137,7 +137,7 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
   } else if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->function_name());
+        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
       case kInclusive:
         return function_item->GetInclusivePercent(call_tree_view_->sample_count());
       case kExclusive:
@@ -145,7 +145,7 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
       case kOfParent:
         return function_item->GetPercentOfParent();
       case kModule:
-        return QString::fromStdString(function_item->GetModuleName());
+        return QString::fromStdString(function_item->RetrieveModuleName(*call_tree_view_));
       case kFunctionAddress:
         return static_cast<qulonglong>(function_item->function_absolute_address());
     }
@@ -171,7 +171,7 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
   return {};
 }
 
-QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) {
+QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) const {
   ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
@@ -179,9 +179,9 @@ QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) {
   if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->function_name());
+        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
       case kModule:
-        return QString::fromStdString(function_item->module_path());
+        return QString::fromStdString(function_item->RetrieveModulePath(*call_tree_view_));
     }
   } else if (unwind_error_type_item != nullptr) {
     switch (index.column()) {
@@ -214,22 +214,22 @@ QVariant CallTreeViewItemModel::GetForegroundRoleData(const QModelIndex& index) 
   return {};
 }
 
-QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) {
+QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) const {
   ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
-    return QString::fromStdString(function_item->module_path());
+    return QString::fromStdString(function_item->RetrieveModulePath(*call_tree_view_));
   }
   return {};
 }
 
-QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& index) {
+QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& index) const {
   ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
-    return QString::fromStdString(function_item->module_build_id());
+    return QString::fromStdString(function_item->RetrieveModuleBuildId(*call_tree_view_));
   }
   return {};
 }

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -61,7 +61,8 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
   } else if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveFunctionName(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
       case kInclusive:
         return QString::fromStdString(absl::StrFormat(
             "%.2f%% (%llu)", function_item->GetInclusivePercent(call_tree_view_->sample_count()),
@@ -74,7 +75,8 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
         return QString::fromStdString(
             absl::StrFormat("%.2f%%", function_item->GetPercentOfParent()));
       case kModule:
-        return QString::fromStdString(function_item->RetrieveModuleName(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveModuleName(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
       case kFunctionAddress:
         return QString::fromStdString(
             absl::StrFormat("%#llx", function_item->function_absolute_address()));
@@ -137,7 +139,8 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
   } else if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveFunctionName(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
       case kInclusive:
         return function_item->GetInclusivePercent(call_tree_view_->sample_count());
       case kExclusive:
@@ -145,7 +148,8 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
       case kOfParent:
         return function_item->GetPercentOfParent();
       case kModule:
-        return QString::fromStdString(function_item->RetrieveModuleName(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveModuleName(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
       case kFunctionAddress:
         return static_cast<qulonglong>(function_item->function_absolute_address());
     }
@@ -179,9 +183,11 @@ QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) con
   if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        return QString::fromStdString(function_item->RetrieveFunctionName(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveFunctionName(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
       case kModule:
-        return QString::fromStdString(function_item->RetrieveModulePath(*call_tree_view_));
+        return QString::fromStdString(function_item->RetrieveModulePath(
+            call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
     }
   } else if (unwind_error_type_item != nullptr) {
     switch (index.column()) {
@@ -219,7 +225,8 @@ QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) 
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
-    return QString::fromStdString(function_item->RetrieveModulePath(*call_tree_view_));
+    return QString::fromStdString(function_item->RetrieveModulePath(
+        call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
   }
   return {};
 }
@@ -229,7 +236,8 @@ QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& inde
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
-    return QString::fromStdString(function_item->RetrieveModuleBuildId(*call_tree_view_));
+    return QString::fromStdString(function_item->RetrieveModuleBuildId(
+        call_tree_view_->GetModuleManager(), call_tree_view_->GetCaptureData()));
   }
   return {};
 }
@@ -364,7 +372,7 @@ QModelIndex CallTreeViewItemModel::index(int row, int column, const QModelIndex&
 
   const CallTreeNode* parent_item = nullptr;
   if (!parent.isValid()) {
-    parent_item = call_tree_view_.get();
+    parent_item = call_tree_view_->GetCallTreeRootNode();
   } else {
     parent_item = static_cast<CallTreeNode*>(parent.internalPointer());
   }
@@ -384,7 +392,7 @@ QModelIndex CallTreeViewItemModel::parent(const QModelIndex& index) const {
 
   auto* child_item = static_cast<CallTreeNode*>(index.internalPointer());
   const CallTreeNode* item = child_item->parent();
-  if (item == call_tree_view_.get()) {
+  if (item == call_tree_view_->GetCallTreeRootNode()) {
     return {};
   }
 
@@ -404,7 +412,7 @@ int CallTreeViewItemModel::rowCount(const QModelIndex& parent) const {
     return 0;
   }
   if (!parent.isValid()) {
-    return call_tree_view_->child_count();
+    return call_tree_view_->GetCallTreeRootNode()->child_count();
   }
   auto* item = static_cast<CallTreeNode*>(parent.internalPointer());
   return item->child_count();

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -372,7 +372,7 @@ QModelIndex CallTreeViewItemModel::index(int row, int column, const QModelIndex&
 
   const CallTreeNode* parent_item = nullptr;
   if (!parent.isValid()) {
-    parent_item = call_tree_view_->GetRootCallTreeNode();
+    parent_item = call_tree_view_->GetCallTreeRoot();
   } else {
     parent_item = static_cast<CallTreeNode*>(parent.internalPointer());
   }
@@ -392,7 +392,7 @@ QModelIndex CallTreeViewItemModel::parent(const QModelIndex& index) const {
 
   auto* child_item = static_cast<CallTreeNode*>(index.internalPointer());
   const CallTreeNode* item = child_item->parent();
-  if (item == call_tree_view_->GetRootCallTreeNode()) {
+  if (item == call_tree_view_->GetCallTreeRoot()) {
     return {};
   }
 
@@ -412,7 +412,7 @@ int CallTreeViewItemModel::rowCount(const QModelIndex& parent) const {
     return 0;
   }
   if (!parent.isValid()) {
-    return call_tree_view_->GetRootCallTreeNode()->child_count();
+    return call_tree_view_->GetCallTreeRoot()->child_count();
   }
   auto* item = static_cast<CallTreeNode*>(parent.internalPointer());
   return item->child_count();

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -372,7 +372,7 @@ QModelIndex CallTreeViewItemModel::index(int row, int column, const QModelIndex&
 
   const CallTreeNode* parent_item = nullptr;
   if (!parent.isValid()) {
-    parent_item = call_tree_view_->GetCallTreeRootNode();
+    parent_item = call_tree_view_->GetRootCallTreeNode();
   } else {
     parent_item = static_cast<CallTreeNode*>(parent.internalPointer());
   }
@@ -392,7 +392,7 @@ QModelIndex CallTreeViewItemModel::parent(const QModelIndex& index) const {
 
   auto* child_item = static_cast<CallTreeNode*>(index.internalPointer());
   const CallTreeNode* item = child_item->parent();
-  if (item == call_tree_view_->GetCallTreeRootNode()) {
+  if (item == call_tree_view_->GetRootCallTreeNode()) {
     return {};
   }
 
@@ -412,7 +412,7 @@ int CallTreeViewItemModel::rowCount(const QModelIndex& parent) const {
     return 0;
   }
   if (!parent.isValid()) {
-    return call_tree_view_->GetCallTreeRootNode()->child_count();
+    return call_tree_view_->GetRootCallTreeNode()->child_count();
   }
   auto* item = static_cast<CallTreeNode*>(parent.internalPointer());
   return item->child_count();

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -100,8 +100,7 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
 TEST(CallTreeViewItemModel, AbstractItemModelTesterEmptyModel) {
   orbit_qt_utils::AssertNoQtLogWarnings message_handler{};
 
-  CallTreeViewItemModel model{
-      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr)};
+  CallTreeViewItemModel model{std::make_unique<CallTreeView>()};
 
   QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Warning);
 }

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
 TEST(CallTreeViewItemModel, AbstractItemModelTesterEmptyModel) {
   orbit_qt_utils::AssertNoQtLogWarnings message_handler{};
 
-  CallTreeViewItemModel model{std::make_unique<CallTreeView>()};
+  CallTreeViewItemModel model{std::make_unique<CallTreeView>(nullptr, nullptr)};
 
   QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Warning);
 }
@@ -116,7 +116,7 @@ TEST(CallTreeViewItemModel, AbstractItemModelTesterFilledModel) {
                                                           *capture_data, module_manager);
 
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-      sampling_data, module_manager, *capture_data);
+      sampling_data, &module_manager, capture_data.get());
 
   CallTreeViewItemModel model{std::move(call_tree_view)};
 
@@ -132,7 +132,7 @@ TEST(CallTreeViewItemModel, RowsWithoutSummaryItem) {
       orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                           *capture_data, module_manager);
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-      sampling_data, module_manager, *capture_data);
+      sampling_data, &module_manager, capture_data.get());
 
   CallTreeViewItemModel model{std::move(call_tree_view)};
 
@@ -150,7 +150,7 @@ TEST(CallTreeViewItemModel, RowsWithSummaryItem) {
       orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                           *capture_data, module_manager);
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-      sampling_data, module_manager, *capture_data);
+      sampling_data, &module_manager, capture_data.get());
 
   CallTreeViewItemModel model{std::move(call_tree_view)};
 
@@ -166,7 +166,7 @@ TEST(CallTreeViewItemModel, GetDisplayRoleData) {
                                                           *capture_data, module_manager);
 
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-      sampling_data, module_manager, *capture_data);
+      sampling_data, &module_manager, capture_data.get());
 
   CallTreeViewItemModel model{std::move(call_tree_view)};
 
@@ -336,7 +336,7 @@ TEST(CallTreeViewItemModel, GetEditRoleData) {
                                                           *capture_data, module_manager);
 
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-      sampling_data, module_manager, *capture_data);
+      sampling_data, &module_manager, capture_data.get());
 
   CallTreeViewItemModel model{std::move(call_tree_view)};
 

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -100,7 +100,8 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
 TEST(CallTreeViewItemModel, AbstractItemModelTesterEmptyModel) {
   orbit_qt_utils::AssertNoQtLogWarnings message_handler{};
 
-  CallTreeViewItemModel model{std::make_unique<CallTreeView>(nullptr, nullptr)};
+  CallTreeViewItemModel model{
+      std::make_unique<CallTreeView>(std::make_unique<CallTreeRoot>(), nullptr, nullptr)};
 
   QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Warning);
 }

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -221,7 +221,7 @@ static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelInd
 void CallTreeWidget::SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) {
   // Expand recursively if CallTreeView contains information for a single thread.
   bool should_expand =
-      IsSliderEnabled() && top_down_view->GetCallTreeRootNode()->thread_count() == 1;
+      IsSliderEnabled() && top_down_view->GetRootCallTreeNode()->thread_count() == 1;
 
   SetCallTreeView(std::move(top_down_view),
                   std::make_unique<HideValuesForTopDownProxyModel>(nullptr));

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -220,8 +220,7 @@ static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelInd
 
 void CallTreeWidget::SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) {
   // Expand recursively if CallTreeView contains information for a single thread.
-  bool should_expand =
-      IsSliderEnabled() && top_down_view->GetRootCallTreeNode()->thread_count() == 1;
+  bool should_expand = IsSliderEnabled() && top_down_view->GetCallTreeRoot()->thread_count() == 1;
 
   SetCallTreeView(std::move(top_down_view),
                   std::make_unique<HideValuesForTopDownProxyModel>(nullptr));

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -220,7 +220,8 @@ static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelInd
 
 void CallTreeWidget::SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) {
   // Expand recursively if CallTreeView contains information for a single thread.
-  bool should_expand = IsSliderEnabled() && top_down_view->thread_count() == 1;
+  bool should_expand =
+      IsSliderEnabled() && top_down_view->GetCallTreeRootNode()->thread_count() == 1;
 
   SetCallTreeView(std::move(top_down_view),
                   std::make_unique<HideValuesForTopDownProxyModel>(nullptr));

--- a/src/OrbitQt/include/OrbitQt/CallTreeViewItemModel.h
+++ b/src/OrbitQt/include/OrbitQt/CallTreeViewItemModel.h
@@ -55,10 +55,10 @@ class CallTreeViewItemModel : public QAbstractItemModel {
  private:
   [[nodiscard]] QVariant GetDisplayRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetEditRoleData(const QModelIndex& index) const;
-  [[nodiscard]] static QVariant GetToolTipRoleData(const QModelIndex& index);
+  [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
   [[nodiscard]] static QVariant GetForegroundRoleData(const QModelIndex& index);
-  [[nodiscard]] static QVariant GetModulePathRoleData(const QModelIndex& index);
-  [[nodiscard]] static QVariant GetModuleBuildIdRoleData(const QModelIndex& index);
+  [[nodiscard]] QVariant GetModulePathRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetModuleBuildIdRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetCopyableValueRoleData(const QModelIndex& index) const;
   [[nodiscard]] static QVariant GetExclusiveCallstackEventsRoleData(const QModelIndex& index);
 


### PR DESCRIPTION
The function nodes of the CallTreeView always stored three strings, for module path, build id and function name. Many of them were even highly redundant.

As we build the complete tree in memory, we not only allocate/deallocate a big amount of memory on the heap, but als querry function/module names for all nodes, even if they are not visible.

In general, Qt is very good at caching and only queries item view items that are visible.

So this change removes the three strings, and instead retrieve the content on query.

This reduces the time to update the UI in the 5min test capture from 29sec to 17sec.

Test: Take a capture of Orbit loading the 5min test capture.