### PR TITLE
Add ParameterPackTrait

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/NotFoundOr.h
         include/OrbitBase/GetProcessIds.h
         include/OrbitBase/Overloaded.h
+        include/OrbitBase/ParameterPackTrait.h
         include/OrbitBase/Profiling.h
         include/OrbitBase/Promise.h
         include/OrbitBase/PromiseHelpers.h
@@ -120,6 +121,7 @@ target_sources(OrbitBaseTests PRIVATE
         LoggingUtilsTest.cpp
         NotFoundOrTest.cpp
         OverloadedTest.cpp
+        ParameterPackTraitTest.cpp
         ProfilingTest.cpp
         PromiseTest.cpp
         PromiseHelpersTest.cpp

--- a/src/OrbitBase/ParameterPackTraitTest.cpp
+++ b/src/OrbitBase/ParameterPackTraitTest.cpp
@@ -16,21 +16,21 @@ namespace orbit_base {
 
 TEST(ParameterPackTrait, Size) {
   // Empty packs are supported
-  static_assert(ParameterPackTrait<std::variant>::Size() == 0);
+  static_assert(ParameterPackTrait<std::variant>::kSize == 0);
 
-  static_assert(ParameterPackTrait<std::variant, int>::Size() == 1);
-  static_assert(ParameterPackTrait<std::variant, int, float>::Size() == 2);
+  static_assert(ParameterPackTrait<std::variant, int>::kSize == 1);
+  static_assert(ParameterPackTrait<std::variant, int, float>::kSize == 2);
 
   // Duplicate types count as distinct pack elements - it's not a set
-  static_assert(ParameterPackTrait<std::variant, int, int, int>::Size() == 3);
+  static_assert(ParameterPackTrait<std::variant, int, int, int>::kSize == 3);
 }
 
 TEST(ParameterPackTrait, Contains) {
-  static_assert(ParameterPackTrait<std::variant, int, float, double>::Contains<int>());
-  static_assert(!ParameterPackTrait<std::variant, int, float, double>::Contains<char>());
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::kContains<int>);
+  static_assert(!ParameterPackTrait<std::variant, int, float, double>::kContains<char>);
 
   // Contains returns true even if the type is more than once in the pack
-  static_assert(ParameterPackTrait<std::variant, int, float, double, int>::Contains<int>());
+  static_assert(ParameterPackTrait<std::variant, int, float, double, int>::kContains<int>);
 }
 
 TEST(ParameterPackTrait, IsSubset) {
@@ -70,40 +70,38 @@ TEST(ParameterPackTrait, IsSubset) {
 }
 
 TEST(ParameterPackTrait, ToType) {
-  static_assert(
-      std::is_same_v<decltype(ParameterPackTrait<std::tuple, int, float, double>::ToType()),
-                     std::tuple<int, float, double>>);
-  static_assert(
-      std::is_same_v<decltype(ParameterPackTrait<std::variant, int, float, double>::ToType()),
-                     std::variant<int, float, double>>);
+  static_assert(std::is_same_v<ParameterPackTrait<std::tuple, int, float, double>::Type,
+                               std::tuple<int, float, double>>);
+  static_assert(std::is_same_v<ParameterPackTrait<std::variant, int, float, double>::Type,
+                               std::variant<int, float, double>>);
 }
 
 TEST(ParameterPackTrait, RemoveDuplicateTypes) {
-  static_assert(ParameterPackTrait<std::variant, int, int>::RemoveDuplicateTypes() ==
+  static_assert(ParameterPackTrait<std::variant, int, int>::DuplicateTypesRemoved{} ==
                 ParameterPackTrait<std::variant, int>{});
   static_assert(
-      ParameterPackTrait<std::variant, int, float, int, double, int>::RemoveDuplicateTypes() ==
+      ParameterPackTrait<std::variant, int, float, int, double, int>::DuplicateTypesRemoved{} ==
       ParameterPackTrait<std::variant, int, float, double>{});
   static_assert(
-      ParameterPackTrait<std::variant, int, float, int, double, int>::RemoveDuplicateTypes() !=
+      ParameterPackTrait<std::variant, int, float, int, double, int>::DuplicateTypesRemoved{} !=
       ParameterPackTrait<std::variant, float, int, double>{});
 }
 
 TEST(ParameterPackTrait, HasDuplicates) {
   // No duplicates in empty pack
-  static_assert(!ParameterPackTrait<std::variant>::HasDuplicates());
+  static_assert(!ParameterPackTrait<std::variant>::kHasDuplicates);
 
   // No duplicates in single element pack
-  static_assert(!ParameterPackTrait<std::variant, int>::HasDuplicates());
+  static_assert(!ParameterPackTrait<std::variant, int>::kHasDuplicates);
 
   // Duplicates in pack with 2 identical types
-  static_assert(ParameterPackTrait<std::variant, int, int>::HasDuplicates());
+  static_assert(ParameterPackTrait<std::variant, int, int>::kHasDuplicates);
 
   // No duplicates in pack with 2 distinct types
-  static_assert(!ParameterPackTrait<std::variant, int, char>::HasDuplicates());
+  static_assert(!ParameterPackTrait<std::variant, int, char>::kHasDuplicates);
 
   // Order doesn't matter - Duplicates still found
-  static_assert(ParameterPackTrait<std::variant, int, char, int>::HasDuplicates());
+  static_assert(ParameterPackTrait<std::variant, int, char, int>::kHasDuplicates);
 }
 
 TEST(ParameterPackTrait, MakeParameterPackTrait) {

--- a/src/OrbitBase/ParameterPackTraitTest.cpp
+++ b/src/OrbitBase/ParameterPackTraitTest.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <variant>
+
+#include "OrbitBase/ParameterPackTrait.h"
+
+namespace orbit_base {
+
+// All these tests are compile-time tests. Technically they don't need to be put in gtest TEST()
+// directives. But it gives them some structure.
+
+TEST(ParameterPackTrait, Size) {
+  // Empty packs are supported
+  static_assert(ParameterPackTrait<std::variant>::Size() == 0);
+
+  static_assert(ParameterPackTrait<std::variant, int>::Size() == 1);
+  static_assert(ParameterPackTrait<std::variant, int, float>::Size() == 2);
+
+  // Duplicate types count as distinct pack elements - it's not a set
+  static_assert(ParameterPackTrait<std::variant, int, int, int>::Size() == 3);
+}
+
+TEST(ParameterPackTrait, Contains) {
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::Contains<int>());
+  static_assert(!ParameterPackTrait<std::variant, int, float, double>::Contains<char>());
+
+  // Contains returns true even if the type is more than once in the pack
+  static_assert(ParameterPackTrait<std::variant, int, float, double, int>::Contains<int>());
+}
+
+TEST(ParameterPackTrait, IsSubset) {
+  // An empty pack is always a subset of any other pack, including an empty pack
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::IsSubset<>());
+  static_assert(ParameterPackTrait<std::variant>::IsSubset<>());
+
+  // Works for single elements
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::IsSubset<int>());
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::IsSubset(
+      ParameterPackTrait<std::variant, int>{}));
+
+  // Works for packs with unique elements (sets)
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::IsSubset<int, double>());
+  static_assert(ParameterPackTrait<std::variant, int, float, double>::IsSubset(
+      ParameterPackTrait<std::variant, int, double>{}));
+
+  // Also returns true when sets are equal
+  static_assert(
+      ParameterPackTrait<std::variant, int, float, double>::IsSubset<float, int, double>());
+
+  // Returns false if single element doesn't match
+  static_assert(!ParameterPackTrait<std::variant, int, float, double>::IsSubset<char>());
+
+  // Returns false if any single element doesn't match
+  static_assert(!ParameterPackTrait<std::variant, int, float, double>::IsSubset<int, char>());
+
+  // Returns false independent of the position of the non-matching element in the pack
+  static_assert(
+      !ParameterPackTrait<std::variant, int, float, double>::IsSubset<int, char, double>());
+  static_assert(
+      !ParameterPackTrait<std::variant, int, float, double>::IsSubset<char, float, int, double>());
+
+  // The packs are treated as sets - so duplicate elements are not considered. Hence `<int, int>` is
+  // a subset of `<int>`.
+  static_assert(ParameterPackTrait<std::variant, int>::IsSubset<int, int>());
+}
+
+TEST(ParameterPackTrait, ToType) {
+  static_assert(
+      std::is_same_v<decltype(ParameterPackTrait<std::tuple, int, float, double>::ToType()),
+                     std::tuple<int, float, double>>);
+  static_assert(
+      std::is_same_v<decltype(ParameterPackTrait<std::variant, int, float, double>::ToType()),
+                     std::variant<int, float, double>>);
+}
+
+TEST(ParameterPackTrait, RemoveDuplicateTypes) {
+  static_assert(ParameterPackTrait<std::variant, int, int>::RemoveDuplicateTypes() ==
+                ParameterPackTrait<std::variant, int>{});
+  static_assert(
+      ParameterPackTrait<std::variant, int, float, int, double, int>::RemoveDuplicateTypes() ==
+      ParameterPackTrait<std::variant, int, float, double>{});
+  static_assert(
+      ParameterPackTrait<std::variant, int, float, int, double, int>::RemoveDuplicateTypes() !=
+      ParameterPackTrait<std::variant, float, int, double>{});
+}
+
+TEST(ParameterPackTrait, HasDuplicates) {
+  // No duplicates in empty pack
+  static_assert(!ParameterPackTrait<std::variant>::HasDuplicates());
+
+  // No duplicates in single element pack
+  static_assert(!ParameterPackTrait<std::variant, int>::HasDuplicates());
+
+  // Duplicates in pack with 2 identical types
+  static_assert(ParameterPackTrait<std::variant, int, int>::HasDuplicates());
+
+  // No duplicates in pack with 2 distinct types
+  static_assert(!ParameterPackTrait<std::variant, int, char>::HasDuplicates());
+
+  // Order doesn't matter - Duplicates still found
+  static_assert(ParameterPackTrait<std::variant, int, char, int>::HasDuplicates());
+}
+
+TEST(ParameterPackTrait, MakeParameterPackTrait) {
+  // MakeParameterPackTrait deduces the variadic value template and the pack automatically when a
+  // value that matches the type construct `Holder<Pack...>` is passed in.
+  static_assert(MakeParameterPackTrait(std::variant<int, float, double>{}) ==
+                ParameterPackTrait<std::variant, int, float, double>{});
+
+  // Template parameters can also be partially provided, while a value is passed in. If this value
+  // matches the given variadic template the pack is deduced as shown before.
+  static_assert(MakeParameterPackTrait<std::variant>(std::variant<int, float, double>{}) ==
+                ParameterPackTrait<std::variant, int, float, double>{});
+
+  // If the provided value does not match the given variadic template, the value is considered the
+  // only type in the pack. This is useful for generic code.
+  static_assert(MakeParameterPackTrait<std::variant>(std::tuple<int, float, double>{}) ==
+                ParameterPackTrait<std::variant, std::tuple<int, float, double>>{});
+  static_assert(MakeParameterPackTrait<std::variant>(int{}) ==
+                ParameterPackTrait<std::variant, int>{});
+}
+
+TEST(ParameterPackTrait, AppendTypes) {
+  // variant<int, double, float> + variant<int, char> -> variant<int, double, float, int, char>
+
+  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+  static_assert(ParameterPackTrait<std::variant, int, double, float>{}.AppendTypes<int, char>() ==
+                ParameterPackTrait<std::variant, int, double, float, int, char>{});
+
+  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+  static_assert(ParameterPackTrait<std::variant, int, double, float>{}.AppendTypes(
+                    ParameterPackTrait<std::variant, int, char>{}) ==
+                ParameterPackTrait<std::variant, int, double, float, int, char>{});
+
+  // variant<int, int, double, float> + variant<int, char, int> -> variant<int, int, double, float,
+  // int, char, int>
+
+  static_assert(  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+      ParameterPackTrait<std::variant, int, int, double, float>{}.AppendTypes<int, char, int>() ==
+      ParameterPackTrait<std::variant, int, int, double, float, int, char, int>{});
+
+  static_assert(  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+      ParameterPackTrait<std::variant, int, int, double, float>{}.AppendTypes(
+          ParameterPackTrait<std::variant, int, char, int>{}) ==
+      ParameterPackTrait<std::variant, int, int, double, float, int, char, int>{});
+
+  // variant<int, int, int> + variant<int, int, int> -> variant<int>
+
+  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+  static_assert(ParameterPackTrait<std::variant, int, int, int>{}.AppendTypes<int, int, int>() ==
+                ParameterPackTrait<std::variant, int, int, int, int, int, int>{});
+
+  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+  static_assert(ParameterPackTrait<std::variant, int, int, int>{}.AppendTypes(
+                    ParameterPackTrait<std::variant, int, int, int>{}) ==
+                ParameterPackTrait<std::variant, int, int, int, int, int, int>{});
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ParameterPackTrait.h
+++ b/src/OrbitBase/include/OrbitBase/ParameterPackTrait.h
@@ -1,0 +1,203 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_PARAMETER_PACK_TRAIT_H_
+#define ORBIT_BASE_PARAMETER_PACK_TRAIT_H_
+
+#include <stddef.h>
+
+#include <tuple>
+#include <type_traits>
+
+namespace orbit_base {
+template <template <typename...> typename, typename...>
+struct ParameterPackTrait;
+}
+
+namespace orbit_base_internal {
+
+// This is a helper type that is needed to implement `ParameterPackTrait::RemoveDuplicateTypes()`.
+// It is based on recursion - AFAIK there is currently no other way to implement this.
+// The recursion depth is O(N), the number of type comparisons is O(N^2). This is far from great,
+// but since our use cases are usually N \in {1, 2, 3}, it's also not that concerning.
+template <typename Output, typename Input>
+struct DeduplicatedTuple;
+
+template <typename... OutputTypes, typename FirstInput, typename... OtherInputTypes>
+struct DeduplicatedTuple<std::tuple<OutputTypes...>, std::tuple<FirstInput, OtherInputTypes...>> {
+  using type = typename std::conditional_t<
+      orbit_base::ParameterPackTrait<std::tuple, OutputTypes...>::template Contains<FirstInput>(),
+      typename DeduplicatedTuple<std::tuple<OutputTypes...>, std::tuple<OtherInputTypes...>>::type,
+      typename DeduplicatedTuple<std::tuple<OutputTypes..., FirstInput>,
+                                 std::tuple<OtherInputTypes...>>::type>;
+};
+
+template <typename... OutputTypes>
+struct DeduplicatedTuple<std::tuple<OutputTypes...>, std::tuple<>> {
+  using type = std::tuple<OutputTypes...>;
+};
+
+template <typename Tuple>
+using DeduplicatedTuple_t = typename DeduplicatedTuple<std::tuple<>, Tuple>::type;
+
+template <typename Tuple>
+struct TupleToParameterPackTraits;
+
+template <typename... Types>
+struct TupleToParameterPackTraits<std::tuple<Types...>> {
+  using type = orbit_base::ParameterPackTrait<std::tuple, Types...>;
+};
+
+template <typename Tuple>
+using TupleToParameterPackTraits_t = typename TupleToParameterPackTraits<Tuple>::type;
+
+}  // namespace orbit_base_internal
+
+namespace orbit_base {
+
+// This is a trait that helps you deal with a parameter pack `Types...`. It also captures a variadic
+// holder template type (any template that takes a parameter pack as its argument - like
+// `std::variant` or `std::tuple`). For example `ParameterPackTrait<std::tuple, int, char>`
+// describes the type `std::tuple<int, char>`.
+//
+// An instance of this trait can be constructed either through default construction or from an
+// existing value using the `MakeParameterPackTrait` constexpr factory function below. Look there
+// for more details.
+//
+// The trait provides a variety of helper functions to deal with parameter packs. They are
+// documented below in the code.
+template <template <typename...> typename VariadicHolder, typename... Types>
+struct ParameterPackTrait {
+  // Returns true iff the given type `T` is part of the parameter pack.
+  template <typename T>
+  [[nodiscard]] constexpr static bool Contains() {
+    return (std::is_same_v<Types, T> || ...);
+  }
+
+  // Return true iff the types listed in `Others...` is a subset of the parameter pack.
+  template <typename... Others>
+  [[nodiscard]] constexpr static bool IsSubset() {
+    return (Contains<Others>() && ...);
+  }
+
+  // Return true iff the types listed in `Others...` is a subset of the parameter pack.
+  template <typename... Others>
+  [[nodiscard]] constexpr static bool IsSubset(
+      const ParameterPackTrait<VariadicHolder, Others...>& /* other*/) {
+    return (Contains<Others>() && ...);
+  }
+
+  // Returns a `ParameterPackTrait` object where duplicate types in `Types` have been removed. The
+  // order of types is not changed and it is guaranteed that the first appearance of a
+  // distinct type in `Types` remains.
+  // Note that this function is rather heavy on type instantiations and can slow down your build
+  // when used with a large parameter pack.
+  [[nodiscard]] constexpr static auto RemoveDuplicateTypes() {
+    return orbit_base_internal::TupleToParameterPackTraits_t<
+               orbit_base_internal::DeduplicatedTuple_t<std::tuple<Types...>>>{}
+        .template ChangeVariadicHolder<VariadicHolder>();
+  }
+
+  // Constructs a value of type `VariadicHolder<Types...>` from the given arguments.
+  template <typename... Args>
+  [[nodiscard]] constexpr static VariadicHolder<Types...> ConstructValue(Args&&... args) {
+    return {std::forward<Args>(args)...};
+  }
+
+  // With `decltype(trait.ToType())` you will get access to the type that this trait represents.
+  // If your intention is to construct a new object, then `ConstructValue` from above might be
+  // cleaner.
+  [[nodiscard]] constexpr static VariadicHolder<Types...> ToType() {
+    // Note that `std::declval` can only appear in an unevaluated context, so a call of `ToType`
+    // must be wrapped in a `decltype(...)` expression.
+    return std::declval<VariadicHolder<Types...>>();
+  }
+
+  // Constructs a new trait object that is a copy of the current object, but a list of types is
+  // appended to the parameter pack.
+  //
+  // There is also an overload that accepts an instance of another trait object with the same //
+  // variadic value type. The parameter pack of this other trait objects is appended to the
+  // parameter pack of the current trait object.
+  template <typename... AdditionalTypes>
+  [[nodiscard]] constexpr static ParameterPackTrait<VariadicHolder, Types..., AdditionalTypes...>
+  AppendTypes() {
+    return {};
+  }
+
+  // Overload to the previous function. Look there for details.
+  template <typename... AdditionalTypes>
+  [[nodiscard]] constexpr static ParameterPackTrait<VariadicHolder, Types..., AdditionalTypes...>
+  AppendTypes(
+      const ParameterPackTrait<VariadicHolder, AdditionalTypes...>& /* unused_trait_object */) {
+    return {};
+  }
+
+  // Constructs a new trait object with a different variadic value type.
+  //
+  // For example that allows you to go from a trait that describes `std::tuple<int, char>` to a
+  // trait that describes `std::variant<int, char>`.
+  template <template <typename...> typename NewVariadicHolder>
+  [[nodiscard]] constexpr static ParameterPackTrait<NewVariadicHolder, Types...>
+  ChangeVariadicHolder() {
+    return {};
+  }
+
+  // Returns the number of types in the parameter pack.
+  [[nodiscard]] constexpr static size_t Size() { return sizeof...(Types); }
+
+  // Returns true iff there are duplicate types in the parameter pack. Note that this function calls
+  // `RemoveDuplicateTypes` in its implementation and the same warning about extended compile times
+  // applies here as well.
+  [[nodiscard]] constexpr static bool HasDuplicates() {
+    return RemoveDuplicateTypes().Size() < Size();
+  }
+
+  // These constexpr comparison operators allow to compare constexpr values instead of types which
+  // leads to more idiomatic unit testing code.
+  template <template <typename...> typename Other, typename... OtherTypes>
+  [[nodiscard]] friend constexpr bool operator==(
+      const ParameterPackTrait& /* lhs */,
+      const ParameterPackTrait<Other, OtherTypes...> /* rhs */) {
+    // Two ParameterPackTraits are considered equal if their types match.
+    return std::is_same_v<ParameterPackTrait, ParameterPackTrait<Other, OtherTypes...>>;
+  }
+
+  template <template <typename...> typename Other, typename... OtherTypes>
+  [[nodiscard]] friend constexpr bool operator!=(
+      const ParameterPackTrait& lhs, const ParameterPackTrait<Other, OtherTypes...> rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+// MakeParameterPackTrait creates a trait object - deduced from a value.
+//
+// - We support full deduction. In that case the value's type must be an instantiation of a variadic
+//   template, in other words an instantiation of `Holder<Types...>`.
+// - We also support partial deduction. In that case the Holder template must be provided explicitly
+//   and the `Types` pack will be deduced from the value. If the value's type is an instantiation of
+//   `Holder<Others...>` then `Others...` will become the pack. If the value's type is NOT an
+//   instantiation of `Holder`, then the pack will consist of a single type `decltype(value)`.
+//   Consider the following examples:
+//   `MakePa...(variant<int, char>{})` returns `ParameterPackTrait<variant, int, char>{}`.
+//   `MakePa...<variant>(variant<int, char>{})` returns `ParameterPackTrait<variant, int, char>{}`.
+//   `MakePa...<variant>(0.0f)` returns `ParameterPackTrait<variant, float>{}`.
+//
+//   This is useful in particular for generic code. It allows to construct a type that's always an
+//   instance of `Holder` while avoiding double wrapping (`Holder<Holder<..>>`).
+template <template <typename...> typename VariadicHolder, typename... Types>
+constexpr static ParameterPackTrait<VariadicHolder, Types...> MakeParameterPackTrait(
+    const VariadicHolder<Types...>& /* unused_value */) {
+  return {};
+}
+
+template <template <typename...> typename VariadicHolder, typename Type>
+constexpr static ParameterPackTrait<VariadicHolder, Type> MakeParameterPackTrait(
+    const Type& /* unused_value */) {
+  return {};
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_PARAMETER_PACK_TRAIT_H_


### PR DESCRIPTION
This is adding a helper type to deal with parameter packs. It's written mainly in constexpr-style value based compile time programming. I hope that makes it more intuitive to deal with.

I'm introducing this now to help with a variant-like container for error types like `ErrorMessage`, `NotFound`, and `Canceled`.