### PR TITLE
Return color to introspection timers

### DIFF
--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -18,10 +18,12 @@
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadPool.h"
 #include "OrbitBase/ThreadUtils.h"
 
 using orbit_api::ApiEventVariant;
+using orbit_base::kIntrospectionProcessId;
 using orbit_introspection::IntrospectionEventCallback;
 using orbit_introspection::IntrospectionListener;
 
@@ -102,99 +104,96 @@ void IntrospectionListener::DeferApiEventProcessing(const orbit_api::ApiEventVar
 
 void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id,
                         uint64_t caller_address) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   if (caller_address == kOrbitCallerAddressAuto) {
     caller_address = ORBIT_GET_CALLER_PC();
   }
-  orbit_api::ApiScopeStart api_scope_start{process_id, thread_id, timestamp_ns,  name,
-                                           color,      group_id,  caller_address};
+  orbit_api::ApiScopeStart api_scope_start{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, color, group_id, caller_address};
   IntrospectionListener::DeferApiEventProcessing(api_scope_start);
 }
 
 void orbit_api_stop() {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiScopeStop api_scope_stop{process_id, thread_id, timestamp_ns};
+  orbit_api::ApiScopeStop api_scope_stop{kIntrospectionProcessId, thread_id, timestamp_ns};
   IntrospectionListener::DeferApiEventProcessing(api_scope_stop);
 }
 
 void orbit_api_start_async_v1(const char* name, uint64_t id, orbit_api_color color,
                               uint64_t caller_address) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   if (caller_address == kOrbitCallerAddressAuto) {
     caller_address = ORBIT_GET_CALLER_PC();
   }
-  orbit_api::ApiScopeStartAsync api_scope_start_async{process_id, thread_id, timestamp_ns,  name,
-                                                      id,         color,     caller_address};
+  orbit_api::ApiScopeStartAsync api_scope_start_async{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, id, color, caller_address};
   IntrospectionListener::DeferApiEventProcessing(api_scope_start_async);
 }
 
 void orbit_api_stop_async(uint64_t id) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiScopeStopAsync api_scope_stop_async{process_id, thread_id, timestamp_ns, id};
+  orbit_api::ApiScopeStopAsync api_scope_stop_async{kIntrospectionProcessId, thread_id,
+                                                    timestamp_ns, id};
   IntrospectionListener::DeferApiEventProcessing(api_scope_stop_async);
 }
 
 void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiStringEvent api_string_event{process_id, thread_id, timestamp_ns, str, id, color};
+  orbit_api::ApiStringEvent api_string_event{
+      kIntrospectionProcessId, thread_id, timestamp_ns, str, id, color};
   IntrospectionListener::DeferApiEventProcessing(api_string_event);
 }
 
 void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackInt api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackInt api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_int64(const char* name, int64_t value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackInt64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackInt64 api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint(const char* name, uint32_t value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackUint api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackUint api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint64(const char* name, uint64_t value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackUint64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackUint64 api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_float(const char* name, float value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackFloat api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackFloat api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_double(const char* name, double value, orbit_api_color color) {
-  uint32_t process_id = orbit_base::GetCurrentProcessId();
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-  orbit_api::ApiTrackDouble api_track{process_id, thread_id, timestamp_ns, name, value, color};
+  orbit_api::ApiTrackDouble api_track{
+      kIntrospectionProcessId, thread_id, timestamp_ns, name, value, color};
   IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 

--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -12,14 +12,10 @@ namespace orbit_base {
 // Note that any non-multiple of 4 in the range [2^31+1, 2^32-1] won't clash with valid Linux or
 // Windows thread ids. See table in ThreadUtils.h.
 
+// -- Thread ID Constants --
+
 // Cross-platform invalid thread id.
 static constexpr uint32_t kInvalidThreadId = -1;  // 0xffffffff
-
-// Cross-platform invalid process id.
-static constexpr uint32_t kInvalidProcessId = -1;  // 0xffffffff
-
-// Represents a fake thread id to specify the set of all thread ids of the current process.
-static constexpr uint32_t kAllProcessThreadsTid = -5;
 
 // Represents a fake thread id to specify the set of all thread ids of all processes on the system.
 static constexpr uint32_t kAllThreadsOfAllProcessesTid = -2;
@@ -27,6 +23,18 @@ static constexpr uint32_t kAllThreadsOfAllProcessesTid = -2;
 // Represents a fake thread id to specify the set of all thread ids of all processes on the system
 // that are NOT in the current process.
 static constexpr uint32_t kNotTargetProcessTid = -3;
+
+// Represents a fake thread id to specify the set of all thread ids of the current process.
+static constexpr uint32_t kAllProcessThreadsTid = -5;
+
+// -- Process ID Constants --
+
+// Cross-platform invalid process id.
+static constexpr uint32_t kInvalidProcessId = -1;  // 0xffffffff
+
+// Process ID assigned to introspection scopes.
+static constexpr uint32_t kIntrospectionProcessId = -2;
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_THREAD_CONSTANTS_H_

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -120,6 +120,7 @@
 using orbit_base::CanceledOr;
 using orbit_base::Future;
 using orbit_base::kAllProcessThreadsTid;
+using orbit_base::kIntrospectionProcessId;
 using orbit_base::NotFoundOr;
 
 using orbit_capture_client::CaptureClient;
@@ -131,7 +132,6 @@ using orbit_capture_file::CaptureFile;
 
 using orbit_client_data::CallstackData;
 using orbit_client_data::CallstackEvent;
-using orbit_client_data::CallstackInfo;
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
 using orbit_client_data::ModuleData;
@@ -2137,6 +2137,11 @@ void OrbitApp::SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids
 }
 
 bool OrbitApp::IsTimerActive(const TimerInfo& timer) const {
+  // It doesn't make sense to filter introspection timers using data from the main window.
+  if (timer.process_id() == kIntrospectionProcessId) {
+    return true;
+  }
+
   if (absl::GetFlag(FLAGS_time_range_selection)) {
     const std::optional<TimeRange>& time_range = data_manager_->GetSelectionTimeRange();
     if (time_range.has_value() && !time_range.value().IsTimerInRange(timer)) {


### PR DESCRIPTION
Create an introspection process id constant so that we know which timers belong to an introspection and which do not. Then do not allow them to be inactive.

Bug: http://b/267159836

Issue: https://github.com/google/orbit/issues/4782