### PR TITLE
Add AnyErrorOf helper type

### DIFF
--- a/src/OrbitBase/AnyErrorOfTest.cpp
+++ b/src/OrbitBase/AnyErrorOfTest.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/AnyErrorOf.h"
+#include "OrbitBase/Result.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_base {
+using orbit_test_utils::HasError;
+using testing::Eq;
+
+namespace {
+// We are defining 6 arbitrary error types here. E1..E3 are copyable, while U1...U3 are move-only.
+// All error types need to have `.message()` member function that returns something convertible to
+// `std::string`.
+
+template <typename T>
+struct ErrorBase {
+  [[nodiscard]] static std::string_view message() { return {}; }
+
+  // The error types don't hold any state, so all instances are equal to each other.
+  [[nodiscard]] friend bool operator==(const T& /*unused*/, const T& /*unused*/) { return true; }
+  [[nodiscard]] friend bool operator!=(const T& /*unused*/, const T& /*unused*/) { return false; }
+};
+
+struct E1 : ErrorBase<E1> {};
+struct E2 : ErrorBase<E2> {};
+struct E3 : ErrorBase<E3> {};
+
+template <typename T>
+struct MoveOnlyErrorBase : ErrorBase<T> {
+  MoveOnlyErrorBase() = default;
+  MoveOnlyErrorBase(const MoveOnlyErrorBase&) = delete;
+  MoveOnlyErrorBase(MoveOnlyErrorBase&&) = default;
+  MoveOnlyErrorBase& operator=(const MoveOnlyErrorBase&) = delete;
+  MoveOnlyErrorBase& operator=(MoveOnlyErrorBase&&) = default;
+};
+
+struct U1 : MoveOnlyErrorBase<U1> {};
+struct U2 : MoveOnlyErrorBase<U2> {};
+struct U3 : MoveOnlyErrorBase<U3> {};
+}  // namespace
+
+TEST(AnyErrorOf, CopyConstructionFromErrorType) {
+  E1 error_value{};
+
+  // Copy construction
+  AnyErrorOf<E1, E2> error{error_value};
+
+  EXPECT_TRUE(std::holds_alternative<E1>(error));
+  EXPECT_EQ(error, E1{});
+  EXPECT_NE(error, E2{});
+}
+
+TEST(AnyErrorOf, MoveConstructionFromErrorType) {
+  // Move construction
+  AnyErrorOf<U1, E2> error{U1{}};
+
+  EXPECT_TRUE(std::holds_alternative<U1>(error));
+  EXPECT_EQ(error, U1{});
+  EXPECT_NE(error, E2{});
+}
+
+TEST(AnyErrorOf, CopyAssignmentFromErrorType) {
+  E2 error_value{};
+  AnyErrorOf<E1, E2> error{E1{}};
+
+  // Copy assignment
+  error = error_value;
+
+  EXPECT_TRUE(std::holds_alternative<E2>(error));
+  EXPECT_NE(error, E1{});
+  EXPECT_EQ(error, E2{});
+}
+
+TEST(AnyErrorOf, MoveAssignmentFromErrorType) {
+  AnyErrorOf<E1, U2> error{E1{}};
+
+  // Move assignment
+  error = U2{};
+
+  EXPECT_TRUE(std::holds_alternative<U2>(error));
+  EXPECT_NE(error, E1{});
+  EXPECT_EQ(error, U2{});
+}
+
+TEST(AnyErrorOf, CopyConstructionFromCompatibleAnyErrorOf) {
+  AnyErrorOf<E1, E2> source{E2{}};
+
+  // Copy construction
+  AnyErrorOf<E1, E2, E3> destination{source};
+
+  EXPECT_TRUE(std::holds_alternative<E2>(destination));
+  EXPECT_NE(destination, E1{});
+  EXPECT_EQ(destination, E2{});
+  EXPECT_NE(destination, E3{});
+}
+
+TEST(AnyErrorOf, MoveConstructionFromCompatibleAnyErrorOf) {
+  AnyErrorOf<E1, U2> source{U2{}};
+
+  // Move construction
+  AnyErrorOf<E1, U2, E3> destination{std::move(source)};
+
+  EXPECT_TRUE(std::holds_alternative<U2>(destination));
+  EXPECT_NE(destination, E1{});
+  EXPECT_EQ(destination, U2{});
+  EXPECT_NE(destination, E3{});
+}
+
+TEST(AnyErrorOf, CopyAssignmentFromCompatibleAnyErrorOf) {
+  AnyErrorOf<E1, E2> source{E2{}};
+  AnyErrorOf<E1, E2, E3> destination{};
+
+  // Copy assignment
+  destination = source;
+
+  EXPECT_TRUE(std::holds_alternative<E2>(destination));
+  EXPECT_NE(destination, E1{});
+  EXPECT_EQ(destination, E2{});
+  EXPECT_NE(destination, E3{});
+}
+
+TEST(AnyErrorOf, MoveAssignmentFromCompatibleAnyErrorOf) {
+  AnyErrorOf<U1, E2> source{E2{}};
+  AnyErrorOf<U1, E2, E3> destination{};
+
+  // Move assignment
+  destination = std::move(source);
+
+  EXPECT_TRUE(std::holds_alternative<E2>(destination));
+  EXPECT_NE(destination, U1{});
+  EXPECT_EQ(destination, E2{});
+  EXPECT_NE(destination, E3{});
+}
+
+TEST(AnyErrorOf, OutcomeTryConstructsAnyErrorOfFromErrorType) {
+  const auto converts_result = [&]() -> Result<void, AnyErrorOf<E1, U2>> {
+    // Imagine we call a function that returns `ErrorMessageOr<void>`, but we have to return
+    // `Result<void, AnyErrorOf<ErrorMessage, Canceled>>`. The needed conversion should be
+    // seamless.
+    OUTCOME_TRY((Result<void, E1>{E1{}}));
+    return outcome::success();
+  };
+
+  EXPECT_THAT(converts_result(), HasError(Eq(E1{})));
+}
+
+TEST(AnyErrorOf, OutcomeTryConstructsAnyErrorOfFromCompatibleAnyErrorOf) {
+  const auto converts_result = [&]() -> Result<void, AnyErrorOf<E1, E2, U3>> {
+    // Imagine we call a function that returns `Result<void,AnyErrorOf<ErrorMessage, NotFound>>`,
+    // but we have to return `Result<void, AnyErrorOf<ErrorMessage, Canceled, NotFound>>`.
+    // The needed conversion should be seamless.
+    OUTCOME_TRY((Result<void, AnyErrorOf<E1, E2>>{E1{}}));
+    return outcome::success();
+  };
+
+  EXPECT_THAT(converts_result(), HasError(Eq(E1{})));
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(OrbitBase PRIVATE
 target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/Align.h
+        include/OrbitBase/AnyErrorOf.h
         include/OrbitBase/AnyInvocable.h
         include/OrbitBase/AnyMovable.h
         include/OrbitBase/Append.h
@@ -108,6 +109,7 @@ add_executable(OrbitBaseTests)
 target_sources(OrbitBaseTests PRIVATE
         AlignTest.cpp
         AnyInvocableTest.cpp
+        AnyErrorOfTest.cpp
         AnyMovableTest.cpp
         AppendTest.cpp
         CanceledOrTest.cpp

--- a/src/OrbitBase/include/OrbitBase/AnyErrorOf.h
+++ b/src/OrbitBase/include/OrbitBase/AnyErrorOf.h
@@ -45,7 +45,7 @@ class AnyErrorOf : public std::variant<ErrorTypes...> {
                 "AnyError<ErrorTypes...> must not have duplicate error types.");
 
   template <typename... Types>
-  constexpr static bool kCanBeConstructedFromTypesAndIsNotCopy = []() {
+  constexpr static bool kCanBeConstructedFromTypesAndIsNotCopy = [] {
     constexpr ParameterPackTrait<AnyErrorOf, ErrorTypes...> kThisTrait{};
     constexpr ParameterPackTrait<AnyErrorOf, Types...> kOtherTrait{};
 
@@ -67,11 +67,11 @@ class AnyErrorOf : public std::variant<ErrorTypes...> {
   constexpr static bool kIsAnErrorType =
       ParameterPackTrait<AnyErrorOf, ErrorTypes...>::template kContains<Type>;
 
-  template <typename T>
-  auto ToBase(T&& other) {
+  template <typename Variant>
+  auto ToBase(Variant&& other) {
     return std::visit(
         [](auto&& alternative) -> Base { return std::forward<decltype(alternative)>(alternative); },
-        std::forward<T>(other));
+        std::forward<Variant>(other));
   }
 
   // The following converting constructors/assignment operators allow conversion of any AnyErrorOf

--- a/src/OrbitBase/include/OrbitBase/AnyErrorOf.h
+++ b/src/OrbitBase/include/OrbitBase/AnyErrorOf.h
@@ -1,0 +1,132 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_ANY_ERROR_OF_H_
+#define ORBIT_BASE_ANY_ERROR_OF_H_
+
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "OrbitBase/ParameterPackTrait.h"
+
+namespace orbit_base {
+
+// A wrapper around `std::variant` holding one instance of multiple possible error types. It's
+// mainly meant to be used with `Result` (`Result<T, AnyErrorOf<E1, E2>`) in cases where a function
+// may return one of multiple possible error types. `AnyErrorOf<E1,E2>` has a `.message()` member
+// function that returns the error message of the holding error by forwarding the call to the
+// `.message()` function of the holding error.
+//
+// `AnyErrorOf` behaves like `std::variant` except for the following properties:
+// 1. `ErrorTypes...` may not have duplicate types - all types must be unique.
+// 2. An empty list of `ErrorTypes...` is not allowed.
+// 3. All error types must have a `.message()` function that's either marked `const` or `static` and
+//    that returns something that's convertible to `std::string`.
+// 4. `AnyErrorOf<T1s...>` can be converted into `AnyErrorOf<T2s...>` if `T2s` contains at least all
+//    the types present in `T1s`. The order of the types has no meaning.
+// 5. `AnyErrorOf` can be directly compared (equality and inequality) to a value of one of its error
+//    types if the given error type defines an equality comparison operator. The compared values are
+//    considered equal if `AnyErrorOf` holds a value of the comparing error type and if the equality
+//    comparison operator returns true.
+template <typename... ErrorTypes>
+class AnyErrorOf : public std::variant<ErrorTypes...> {
+  using Base = std::variant<ErrorTypes...>;
+
+ public:
+  using Base::Base;
+  using Base::operator=;
+
+  static_assert(ParameterPackTrait<AnyErrorOf, ErrorTypes...>::kSize >= 1,
+                "AnyError<> (AnyErrorOf with no error types) is not allowed.");
+
+  static_assert(!ParameterPackTrait<AnyErrorOf, ErrorTypes...>::kHasDuplicates,
+                "AnyError<ErrorTypes...> must not have duplicate error types.");
+
+  template <typename... Types>
+  constexpr static bool CanBeConstructedFromTypesAndIsNotCopy() {
+    constexpr ParameterPackTrait<AnyErrorOf, ErrorTypes...> kThisTrait{};
+    constexpr ParameterPackTrait<AnyErrorOf, Types...> kOtherTrait{};
+
+    // We return false if `AnyErrorOf<ErrorTypes...>` is the same type as `AnyErrorOf<Types...>`.
+    // This avoids collisions with the copy and move constructors/assignment operators.
+    if (kThisTrait == kOtherTrait) return false;
+
+    // We only allow conversion from an instance of `AnyErrorOf<Types...>` with `Types` being a
+    // subset of `ErrorTypes`.
+    return kThisTrait.IsSubset(kOtherTrait);
+  }
+
+  // Is true iff `Type` is in the `ErrorTypes...` parameter pack.
+  template <typename Type>
+  constexpr static bool kIsAnErrorType =
+      ParameterPackTrait<AnyErrorOf, ErrorTypes...>::template kContains<Type>;
+
+  // The following converting constructors/assignment operators allow conversion of any AnyErrorOf
+  // type into a compatible AnyErrorOf type. An AnyErrorOf type is considered compatible
+  // if its error type list is a super set of the other's error type list. The order of the types
+  // doesn't matter though.
+  //
+  // Examples:
+  //  - AnyErrorOf<E1> can be converted into AnyErrorOf<E1, E2> but not into AnyErrorOf<E2, E3>.
+  //  - AnyErrorOf<E1, E2> can be converted into AnyErrorOf<E1, E3, E2>.
+  //  - AnyErrorOf<E1, E2> can be converted into AnyErrorOf<E2, E1>.
+  template <typename... Types,
+            std::enable_if_t<CanBeConstructedFromTypesAndIsNotCopy<Types...>(), int> = 0>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  AnyErrorOf(const AnyErrorOf<Types...>& other)
+      : Base{std::visit([](const auto& alternative) -> Base { return alternative; }, other)} {}
+
+  template <typename... Types,
+            std::enable_if_t<CanBeConstructedFromTypesAndIsNotCopy<Types...>(), int> = 0>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  AnyErrorOf(AnyErrorOf<Types...>&& other)
+      : Base{std::visit([](auto&& alternative)
+                            -> Base { return std::forward<decltype(alternative)>(alternative); },
+                        std::move(other))} {}
+
+  template <typename... Types,
+            std::enable_if_t<CanBeConstructedFromTypesAndIsNotCopy<Types...>(), int> = 0>
+  AnyErrorOf& operator=(const AnyErrorOf<Types...>& other) {
+    *this = std::visit([](const auto& alternative) -> Base { return alternative; }, other);
+    return *this;
+  }
+
+  template <typename... Types,
+            std::enable_if_t<CanBeConstructedFromTypesAndIsNotCopy<Types...>(), int> = 0>
+  AnyErrorOf& operator=(AnyErrorOf<Types...>&& other) {
+    *this = std::visit(
+        [](auto&& alternative) -> Base { return std::forward<decltype(alternative)>(alternative); },
+        std::move(other));
+    return *this;
+  }
+
+  [[nodiscard]] std::string message() const {
+    return std::visit([](const auto& error) { return std::string{error.message()}; }, *this);
+  }
+
+  // We allow transparent comparison with any of the error types.
+  template <typename T, std::enable_if_t<kIsAnErrorType<T>, int> = 0>
+  [[nodiscard]] friend bool operator==(const AnyErrorOf& lhs, const T& rhs) {
+    return std::holds_alternative<T>(lhs) && std::get<T>(lhs) == rhs;
+  }
+
+  template <typename T, std::enable_if_t<kIsAnErrorType<T>, int> = 0>
+  [[nodiscard]] friend bool operator==(const T& lhs, const AnyErrorOf& rhs) {
+    return std::holds_alternative<T>(lhs) && std::get<T>(lhs) == rhs;
+  }
+
+  template <typename T, std::enable_if_t<kIsAnErrorType<T>, int> = 0>
+  [[nodiscard]] friend bool operator!=(const AnyErrorOf& lhs, const T& rhs) {
+    return !(lhs == rhs);
+  }
+
+  template <typename T, std::enable_if_t<kIsAnErrorType<T>, int> = 0>
+  [[nodiscard]] friend bool operator!=(const T& lhs, const AnyErrorOf& rhs) {
+    return !(lhs == rhs);
+  }
+};
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_ANY_ERROR_OF_H_


### PR DESCRIPTION
`AnyErrorOf` is a wrapper around `std::variant` and behaves similarly. Exact behavioural deviations are documented in the header.

The main purpose of this type is to replace complex return types that we currently have in the code base, like `ErrorMessageOr<CanceledOr<T>>` or `ErrorMessageOr<CanceledOr<NotFoundOr<T>>>`.

`AnyErrorOf` allows to flatten such constructs to `Result<T, AnyErrorOf<ErrorMessage, Canceled>>` or `Result<T, AnyErrorOf<ErrorMessage, Canceled, NotFound>>`.