### PR TITLE
Use SingleThreadExecutor in ServiceDeployManager

### DIFF
--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -150,8 +150,7 @@ ServiceDeployManager::ServiceDeployManager(const DeploymentConfiguration* deploy
   ORBIT_CHECK(deployment_configuration != nullptr);
   ORBIT_CHECK(context != nullptr);
 
-  background_thread_.start();
-  moveToThread(&background_thread_);
+  moveToThread(background_executor_.GetThread());
 
   QObject::connect(
       this, &ServiceDeployManager::statusMessage, this, [](const QString& status_message) {
@@ -159,11 +158,7 @@ ServiceDeployManager::ServiceDeployManager(const DeploymentConfiguration* deploy
       });
 }
 
-ServiceDeployManager::~ServiceDeployManager() {
-  Shutdown();
-  background_thread_.quit();
-  background_thread_.wait();
-}
+ServiceDeployManager::~ServiceDeployManager() { Shutdown(); }
 
 void ServiceDeployManager::Cancel() {
   // By transforming this function call into a signal we leverage Qt's automatic thread

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -36,6 +36,7 @@
 #include "OrbitSshQt/SftpCopyToRemoteOperation.h"
 #include "OrbitSshQt/Task.h"
 #include "OrbitSshQt/Tunnel.h"
+#include "QtUtils/SingleThreadExecutor.h"
 
 namespace orbit_session_setup {
 
@@ -79,7 +80,7 @@ class ServiceDeployManager : public QObject {
   std::unique_ptr<orbit_ssh_qt::SftpChannel> sftp_channel_;
   QTimer ssh_watchdog_timer_;
 
-  QThread background_thread_;
+  orbit_qt_utils::SingleThreadExecutor background_executor_{};
 
   void Shutdown();
   ErrorMessageOr<void> ConnectToServer();


### PR DESCRIPTION
This replaces the previously existing `QThread background_thread_` by the new `SingleThreadExecutor`.

It will allow scheduling `Future` continuations on the same thread that also processes Qt event loop events.

The usage of `Future`s will be introduced in subsequent PRs.