### PR TITLE
Upgrade required conan version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           py -3 -m pip install aqtinstall
           py -3 -m aqt install-qt  --outputdir C:\Qt windows desktop 5.15 win64_msvc2019_64
-          py -3 -m pip install conan==1.54.0
+          py -3 -m pip install conan==1.58.0
           choco install -y ccache
           echo "C:\ProgramData\chocolatey\lib\ccache\tools\ccache-4.7.3-windows-x86_64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Save CCache Timestamp

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-$conan_version_required = "1.53.0"
+$conan_version_required = "1.58.0"
 
 function Check-Conan-Version-Sufficient {
   $version = [System.Version]$args[0]

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-CONAN_VERSION_REQUIRED="1.53.0"
+CONAN_VERSION_REQUIRED="1.58.0"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/third_party/conan/docker/Dockerfile.clang11_opengl_qt
+++ b/third_party/conan/docker/Dockerfile.clang11_opengl_qt
@@ -36,7 +36,7 @@ RUN useradd -Ums /bin/bash conan \
         ninja-build \
         python3-pip \
         zip \
-    && python3 -m pip install conan==1.53.0 \
+    && python3 -m pip install conan==1.58.0 \
     && rm -rf /var/lib/apt/lists/*
 
 USER conan

--- a/third_party/conan/docker/Dockerfile.coverage_clang11
+++ b/third_party/conan/docker/Dockerfile.coverage_clang11
@@ -37,7 +37,7 @@ RUN useradd -Ums /bin/bash conan \
         ninja-build \
         python3-pip \
         zip \
-    && python3 -m pip install conan==1.53.0 \
+    && python3 -m pip install conan==1.58.0 \
     && rm -rf /var/lib/apt/lists/*
 
 USER conan

--- a/third_party/conan/docker/Dockerfile.gcc10
+++ b/third_party/conan/docker/Dockerfile.gcc10
@@ -37,7 +37,7 @@ RUN useradd -Ums /bin/bash conan \
         ninja-build \
         python3-pip \
         zip \
-    && python3 -m pip install conan==1.53.0 \
+    && python3 -m pip install conan==1.58.0 \
     && rm -rf /var/lib/apt/lists/*
 
 USER conan

--- a/third_party/conan/docker/Dockerfile.iwyu
+++ b/third_party/conan/docker/Dockerfile.iwyu
@@ -39,7 +39,7 @@ RUN useradd -Ums /bin/bash conan \
         zip \
         patchutils \
         iwyu \
-    && python3 -m pip install conan==1.53.0 \
+    && python3 -m pip install conan==1.58.0 \
     && rm -rf /var/lib/apt/lists/*
 
 USER conan

--- a/third_party/conan/scripts/build_and_upload_dependencies.sh
+++ b/third_party/conan/scripts/build_and_upload_dependencies.sh
@@ -19,7 +19,7 @@ readonly SCRIPT="/mnt/third_party/conan/scripts/build_and_upload_dependencies.sh
 export CONAN_USE_ALWAYS_SHORT_PATHS=1
 
 if [[ -v IN_DOCKER ]]; then
-  pip3 install conan==1.53.0
+  pip3 install conan==1.58.0
   export QT_QPA_PLATFORM=offscreen
 
   if [[ -v ORBIT_PUBLIC_BUILD ]]; then

--- a/third_party/conan/scripts/sync_dependencies.sh
+++ b/third_party/conan/scripts/sync_dependencies.sh
@@ -13,7 +13,7 @@ REPO_ROOT_WIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" >/dev/null 2>&
 SCRIPT="/mnt/third_party/conan/scripts/sync_dependencies.sh"
 
 if [ "$1" ]; then
-  pip3 install conan==1.53.0
+  pip3 install conan==1.58.0
   export QT_QPA_PLATFORM=offscreen
 
   $REPO_ROOT/third_party/conan/configs/install.sh || exit $?


### PR DESCRIPTION
A recent upstream change to the `googleapis` conan recipe broke the conan build for some folks in some situation with an error message saying that protobuf was not found.

I analysed the problem and it turns out that the update of `googleapis` triggers a known and fixed bug in Conan and an upgrade of Conan fixes the problem.