### PR TITLE
Release time_range_selection feature

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -62,7 +62,7 @@ ABSL_FLAG(
 
 ABSL_FLAG(bool, auto_frame_track, true, "Automatically add the default Frame Track.");
 
-ABSL_FLAG(bool, time_range_selection, false, "Enable time range selection feature.");
+ABSL_FLAG(bool, time_range_selection, true, "Enable time range selection feature.");
 
 ABSL_FLAG(bool, symbol_store_support, false, "Enable experimental symbol store support.");
 


### PR DESCRIPTION
Having time_range_selection feature is now the default. I will let this soak for a bit before removing the old version.