### PR TITLE
Use AnyErrorOf in Future::ThenIfSuccess

### DIFF
--- a/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
@@ -8,6 +8,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "OrbitBase/AnyErrorOf.h"
+#include "OrbitBase/ParameterPackTrait.h"
 #include "OrbitBase/Promise.h"
 #include "OrbitBase/Result.h"
 
@@ -130,6 +132,30 @@ struct EnsureWrappedInResult {
 template <typename T, typename E>
 struct EnsureWrappedInResult<Result<T, E>, E> {
   using Type = Result<T, E>;
+};
+
+template <typename T, typename E1, typename E2>
+struct EnsureWrappedInResult<Result<T, E1>, E2> {
+  using Type = Result<T, AnyErrorOf<E1, E2>>;
+};
+
+template <typename T, typename... E1s, typename E2>
+struct EnsureWrappedInResult<Result<T, AnyErrorOf<E1s...>>, E2> {
+  using Type = Result<
+      T, decltype(ParameterPackTrait<AnyErrorOf, E1s..., E2>{}.RemoveDuplicateTypes().ToType())>;
+};
+
+template <typename T, typename E1, typename... E2s>
+struct EnsureWrappedInResult<Result<T, E1>, AnyErrorOf<E2s...>> {
+  using Type = Result<
+      T, decltype(ParameterPackTrait<AnyErrorOf, E1, E2s...>{}.RemoveDuplicateTypes().ToType())>;
+};
+
+template <typename T, typename... E1s, typename... E2s>
+struct EnsureWrappedInResult<Result<T, AnyErrorOf<E1s...>>, AnyErrorOf<E2s...>> {
+  using Type = Result<
+      T,
+      decltype(ParameterPackTrait<AnyErrorOf, E1s..., E2s...>{}.RemoveDuplicateTypes().ToType())>;
 };
 
 }  // namespace orbit_base

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -198,9 +198,11 @@ Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleSymbolsAndL
 
         orbit_base::ImmediateExecutor executor;
         return LoadSymbols(local_file_path, module_path_and_build_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> {
-              return CanceledOr<void>{outcome::success()};
-            });
+            .Then(&executor,
+                  [](const ErrorMessageOr<void>& result) -> ErrorMessageOr<CanceledOr<void>> {
+                    OUTCOME_TRY(result);
+                    return CanceledOr<void>{outcome::success()};
+                  });
       });
 }
 
@@ -541,9 +543,11 @@ Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleItselfAndLo
 
         orbit_base::ImmediateExecutor executor;
         return LoadFallbackSymbols(local_file_path, module_path_and_build_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> {
-              return CanceledOr<void>{outcome::success()};
-            });
+            .Then(&executor,
+                  [](const ErrorMessageOr<void>& result) -> ErrorMessageOr<CanceledOr<void>> {
+                    OUTCOME_TRY(result);
+                    return CanceledOr<void>{outcome::success()};
+                  });
       });
 }
 


### PR DESCRIPTION
`Future::ThenIfSuccess` allows to chain a continuation to a future that is only executed when the future completes with no error.

In terms of types that means we have a `Future<Result<T, E>>`, call `.ThenIfSuccess` with a closure `T -> U` or `T -> Result<U, E>` and the result will be a `Future<Result<U, E>>` in both cases.

Imagine you want to chain a closure `T -> Result<U, E2>`. This is currently not supported due to the mismatching error types.

This changes with this PR. `Future<Result<T, E>>::ThenIfSuccess<T -> Result<U, E2>>()` will result in a `Future<Result<U, AnyErrorOf<E, E2>>>`. That allows easier composition of closures with different error types.

Note that this changes the semantics of `ThenIfScuccess` and I had to make some changes in existing code to avoid behavioural changes.