### PR TITLE
Fix crashes when clearing the capture

### DIFF
--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -114,9 +114,8 @@ std::string CallTreeFunction::RetrieveFunctionName(
       module_manager, capture_data, function_absolute_address_);
   if (function_name != orbit_client_data::kUnknownFunctionOrModuleName) {
     return function_name;
-  } else {
-    return absl::StrFormat("[unknown@%#llx]", function_absolute_address_);
   }
+  return absl::StrFormat("[unknown@%#llx]", function_absolute_address_);
 }
 
 std::string CallTreeFunction::RetrieveModulePath(

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -1416,10 +1416,11 @@ void OrbitApp::AbortCapture() {
 
 void OrbitApp::ClearCapture() {
   ORBIT_SCOPE_FUNCTION;
+
+  ClearSamplingRelatedViews();
   if (capture_window_ != nullptr) {
     capture_window_->ClearTimeGraph();
   }
-  ClearSamplingRelatedViews();
   ResetCaptureData();
 
   string_manager_.Clear();


### PR DESCRIPTION
Now the call tree views depend on the capture data, so the order of destruction matters.

Let's get it right.

Also this fixes a clang-tidy warning.

Fixes: #4808