### PR TITLE
Show Top Down Tab after capture

### DIFF
--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -446,6 +446,9 @@ Future<void> OrbitApp::OnCaptureComplete() {
         ORBIT_CHECK(capture_stopped_callback_);
         capture_stopped_callback_();
 
+        if (GetCaptureData().GetAllProvidedScopeIds().empty()) {
+          main_window_->SelectTopDownTab();
+        }
         FireRefreshCallbacks();
 
         if (absl::GetFlag(FLAGS_auto_symbol_loading)) {

--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -68,6 +68,7 @@ class MainWindowInterface {
   virtual void OnSetClipboard(std::string_view text) = 0;
   virtual void RefreshDataView(orbit_data_views::DataViewType type) = 0;
   virtual void SelectLiveTab() = 0;
+  virtual void SelectTopDownTab() = 0;
   virtual std::string OnGetSaveFileName(std::string_view extension) = 0;
 
   virtual void SetErrorMessage(std::string_view title, std::string_view text) = 0;

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -112,6 +112,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void OnSetClipboard(std::string_view text) override;
   void RefreshDataView(orbit_data_views::DataViewType type) override;
   void SelectLiveTab() override;
+  void SelectTopDownTab() override;
   std::string OnGetSaveFileName(std::string_view extension) override;
 
   void SetErrorMessage(std::string_view title, std::string_view text) override;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -2017,3 +2017,4 @@ void OrbitMainWindow::RefreshDataView(DataViewType type) {
 }
 
 void OrbitMainWindow::SelectLiveTab() { ui->RightTabWidget->setCurrentWidget(ui->liveTab); }
+void OrbitMainWindow::SelectTopDownTab() { ui->RightTabWidget->setCurrentWidget(ui->topDownTab); }


### PR DESCRIPTION
For historical reasons, we showed the sampling tab when completing a capture and no instrumation was done.

This behaviour changed recently, such that we were not switching the tab in this case at all, and remain at the modules tab. However, it makes sense to inspect sampling related data after the capture is done.
This change suggest to switch to the top down tab, as most other profilers do.

Test: Take a capture w/ and w/o instrumentation.