### PR TITLE
Fix OrbitClientGgp

### DIFF
--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -115,6 +115,7 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
   options.selected_functions = selected_functions_;
   options.stack_dump_size = options_.stack_dump_size;
+  options.samples_per_second = options_.samples_per_second;
 
   std::filesystem::path file_path = GenerateFilePath();
 


### PR DESCRIPTION
Fix `OrbitClientGgp`. The number of samples per second passed to CaptureClient was 0, set to it to the user-provided value instead. Most likely, the bug was introduced in 5d0d315.