### PR TITLE
Fix LiveFunctionsDataView update during OnCaptureStarted

### DIFF
--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -386,8 +386,11 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
 
     if (!GetCaptureData().GetAllProvidedScopeIds().empty()) {
       main_window_->SelectLiveTab();
-      main_window_->SetLiveTabScopeStatsCollection(GetCaptureData().GetAllScopeStatsCollection());
     }
+    // LiveFunctionsDataView and CaptureData share the same ScopeStatsCollection (shared_ptr),
+    // and since the CaptureData was recreated above we have to update LiveFunctionsDataView
+    // correspondingly.
+    main_window_->SetLiveTabScopeStatsCollection(GetCaptureData().GetAllScopeStatsCollection());
 
     FireRefreshCallbacks();
 


### PR DESCRIPTION
Fixes #4825 
LiveFunctionsDataView had a shared_ptr pointing to the "old" ScopeStatsCollection (remaining from the previous capture) in case there were no hooked functions.