### PR TITLE
Fix highlighting of scheduling slices of same pid

### DIFF
--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2218,7 +2218,9 @@ const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {
 }
 
 void OrbitApp::SelectTimer(const orbit_client_protos::TimerInfo* timer_info) {
-  if (timer_info != nullptr && !IsTimerActive(*timer_info)) return;
+  if (timer_info != nullptr && !IsTimerActive(*timer_info) &&
+      timer_info->type() != TimerInfo::kCoreActivity)
+    return;
 
   data_manager_->set_selected_timer(timer_info);
   const std::optional<ScopeId> scope_id =


### PR DESCRIPTION
https://github.com/google/orbit/pull/4678 broke the previous behavior introduced in https://github.com/google/orbit/pull/2819. Add special case for scheduling slices selection to bring back this feature.