### PR TITLE
Fix drawing of incomplete intervals

### DIFF
--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -322,7 +322,8 @@ void TrackContainer::DrawIncompleteDataIntervals(PrimitiveAssembler& primitive_a
   const float world_height = viewport_->GetWorldHeight();
 
   // Actually draw the ranges.
-  for (const auto& [start_x, end_x] : x_ranges) {
+  for (auto [start_x, end_x] : x_ranges) {
+    start_x = std::max(layout_->GetTrackHeaderWidth(), start_x);
     const Vec2 pos{start_x, world_start_y};
     const Vec2 size{end_x - start_x, world_height};
     float z_value = GlCanvas::kZValueIncompleteDataOverlay;


### PR DESCRIPTION
Incomplete intervals, drawn as orange translucid rectangles, could be drawn over 
the track headers on the left side of the capture view. Make sure we clamp 
the x coordinate. Tested by introducing fake intervals and making sure they aligned
properly on the timeline and that they did not draw over the track headers.