### PR TITLE
Revert time range selection

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -62,7 +62,7 @@ ABSL_FLAG(
 
 ABSL_FLAG(bool, auto_frame_track, true, "Automatically add the default Frame Track.");
 
-ABSL_FLAG(bool, time_range_selection, true, "Enable time range selection feature.");
+ABSL_FLAG(bool, time_range_selection, false, "Enable time range selection feature.");
 
 ABSL_FLAG(bool, symbol_store_support, false, "Enable experimental symbol store support.");
 


### PR DESCRIPTION
This is a nice feature, but unfortunately I found myself having to revert it 
because we can't select individual sampling events anymore, which is a 
huge drawback. Since there is not much active development on the UI 
front, I suggest reverting to the old behavior by default for now.