### PR TITLE
Fix Ubuntu 20.04 and Windows build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,8 +49,8 @@ class OrbitConan(ConanFile):
 
     def build_requirements(self):
         if self.options.with_system_deps: return
-        self.build_requires('protobuf/3.21.4')
         self.build_requires('grpc/1.48.0')
+        self.build_requires('protobuf/3.21.4')
         self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
@@ -154,3 +154,5 @@ class OrbitConan(ConanFile):
 
     def deploy(self):
         self.copy("*", src="bin", dst="bin")
+
+# test ci


### PR DESCRIPTION
Not having conan lockfiles anymore means that we are subject to breakage from upstream. Changing the conan dependency order (grpc before protobuf now) seems to fix the new issue.

To test CI, I temporarily added a  "Kick build" comment in a cpp file as it seems to not trigger if we only change the conanfile.py, here are the results:

<img width="709" alt="image" src="https://github.com/google/orbit/assets/3687222/2700e445-306a-4b56-843b-c40728238059">
