### PR TITLE
Change order of conan dependency to fix Windows build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ on:
       - 'cmake/**'
       - 'src/**'
       - 'third_party/**'
-      - 'conanfile.*'
+      - 'conanfile.py'
   pull_request:
     branches:
       - 'main'

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,8 +49,8 @@ class OrbitConan(ConanFile):
 
     def build_requirements(self):
         if self.options.with_system_deps: return
-        self.build_requires('protobuf/3.21.4')
         self.build_requires('grpc/1.48.0')
+        self.build_requires('protobuf/3.21.4')
         self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):


### PR DESCRIPTION
This fixes the Windows build on mainline, and also ubuntu 20.04 builds.