### PR TITLE
Trace closing of tracing fds by type

### DIFF
--- a/src/LinuxTracing/PerfEventProcessor.cpp
+++ b/src/LinuxTracing/PerfEventProcessor.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "Introspection/Introspection.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
 #include "PerfEvent.h"
@@ -40,6 +41,7 @@ void PerfEventProcessor::AddEvent(PerfEvent&& event) {
 // DiscardedPerfEvents.
 std::optional<DiscardedPerfEvent> PerfEventProcessor::HandleOutOfOrderEvent(
     uint64_t event_timestamp_ns) {
+  ORBIT_SCOPE("PerfEventProcessor::HandleOutOfOrderEvent");
   const uint64_t discarded_begin = event_timestamp_ns;
   const uint64_t discarded_end = last_processed_timestamp_ns_;
 
@@ -84,6 +86,7 @@ std::optional<DiscardedPerfEvent> PerfEventProcessor::HandleOutOfOrderEvent(
 }
 
 void PerfEventProcessor::ProcessAllEvents() {
+  ORBIT_SCOPE("PerfEventProcessor::ProcessAllEvents");
   ORBIT_CHECK(!visitors_.empty());
   while (event_queue_.HasEvent()) {
     const PerfEvent& event = event_queue_.TopEvent();
@@ -99,6 +102,7 @@ void PerfEventProcessor::ProcessAllEvents() {
 }
 
 void PerfEventProcessor::ProcessOldEvents() {
+  ORBIT_SCOPE("PerfEventProcessor::ProcessOldEvents");
   ORBIT_CHECK(!visitors_.empty());
   const uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -166,7 +166,7 @@ class TracerImpl : public Tracer {
   std::atomic<bool> stop_run_thread_ = true;
   std::thread run_thread_;
 
-  std::vector<int> tracing_fds_;
+  absl::flat_hash_map<std::string, std::vector<int>> tracing_fds_by_type_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<int, uint64_t> fds_to_last_timestamp_ns_;
 


### PR DESCRIPTION
A major pain point in the Orbit workflow is "waiting for the capture to be finalized".
Add tracing to better understand where time is spent during that step.

![image](https://github.com/google/orbit/assets/3687222/8b8f3ce2-8b14-47eb-a4c1-abee1973e981)

Add better introspection for capture finalization:

![closing_fds](https://github.com/google/orbit/assets/3687222/dbf87c84-5644-4bd0-a3f6-bd7a41d074c2)

