### PR TITLE
Add ORBIT_LOG_VAR utility macro

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -41,6 +41,8 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
     ORBIT_INTERNAL_PLATFORM_LOG(formatted_log__.c_str());                                    \
   } while (0)
 
+#define ORBIT_LOG_VAR(x) ORBIT_LOG("%s = %s", #x, orbit_base::to_string(x))
+
 #define ORBIT_ERROR(format, ...) ORBIT_LOG("Error: " format, ##__VA_ARGS__)
 
 #define ORBIT_LOG_ONCE(format, ...)                                                   \
@@ -162,6 +164,16 @@ ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir);
 void InitLogFile(const std::filesystem::path& path);
 
 void LogStacktrace();
+
+template <typename T>
+inline std::string to_string(const T& value) {
+  return std::to_string(value);
+}
+
+inline std::string to_string(const std::string& value) { return value; }
+inline std::string to_string(std::string_view value) { return std::string(value); }
+inline std::string to_string(const char* value) { return value; }
+
 }  // namespace orbit_base
 
 namespace orbit_base_internal {


### PR DESCRIPTION
```
int my_int = 3;
ORBIT_LOG_VAR(my_int);
```
> my_int = 3

This is a quality of life macro for development. We need to specify our own "to_string" as std::to_string does not handle string types.