### PR TITLE
Patch to update CONAN_VERSION_REQUIRED to 1.60.0

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-CONAN_VERSION_REQUIRED="1.58.0"
+CONAN_VERSION_REQUIRED="1.60.0"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
This is the PR for updating CONAN_VERSION_REQUIRED to 1.60.0.

I faced the same error as https://github.com/google/orbit/issues/4861 .

The error messages are below.
```
ERROR: googleapis/cci.20221108: Cannot load recipe.
Error loading conanfile at '/home/vagrant/.conan/data/googleapis/cci.20221108/_/_/export/conanfile.py': Current Conan version (1.58.0) does not satisfy the defined one (>=1.60.0 <2 || >=2.0.5).
```

As mentioned above, build succeeded with conan 1.60.0.